### PR TITLE
[lua], [html], [cpp] Organize `chars.hpp`, rename some functions

### DIFF
--- a/include/ulight/impl/strings.hpp
+++ b/include/ulight/impl/strings.hpp
@@ -37,9 +37,9 @@ inline constexpr std::u8string_view all_ascii_alphanumeric8
 inline constexpr std::u32string_view all_ascii_whitespace = U"\t\n\f\r ";
 inline constexpr std::u8string_view all_ascii_whitespace8 = u8"\t\n\f\r ";
 
-// see is_ascii_blank
-inline constexpr std::u32string_view all_ascii_blank = U"\t\n\f\r\v ";
-inline constexpr std::u8string_view all_ascii_blank8 = u8"\t\n\f\r\v ";
+// see is_cpp_whitespace
+inline constexpr std::u32string_view all_cpp_whitespace = U"\t\n\f\r\v ";
+inline constexpr std::u8string_view all_cpp_whitespace8 = u8"\t\n\f\r\v ";
 
 // see is_mmml_escapeable
 inline constexpr std::u32string_view all_mmml_escapeable = U"\\{}";
@@ -92,20 +92,18 @@ constexpr bool is_ascii(std::u8string_view str)
     return detail::all_of(str, predicate);
 }
 
-/// @brief Returns `true` if `str` is a possibly empty ASCII string comprised
-/// entirely of blank ASCII characters (`is_ascii_blank`).
 [[nodiscard]]
-constexpr bool is_ascii_blank(std::u8string_view str)
+constexpr bool is_cpp_whitespace(std::u8string_view str)
 {
-    constexpr auto predicate = [](char8_t x) { return is_ascii_blank(x); };
+    constexpr auto predicate = [](char8_t x) { return is_cpp_whitespace(x); };
     return detail::all_of(str, predicate);
 }
 
 [[nodiscard]]
-constexpr std::u8string_view trim_ascii_blank_left(std::u8string_view str)
+constexpr std::u8string_view trim_cpp_whitespace_left(std::u8string_view str)
 {
     for (std::size_t i = 0; i < str.size(); ++i) {
-        if (!is_ascii_blank(str[i])) {
+        if (!is_cpp_whitespace(str[i])) {
             return str.substr(i);
         }
     }
@@ -113,21 +111,20 @@ constexpr std::u8string_view trim_ascii_blank_left(std::u8string_view str)
 }
 
 [[nodiscard]]
-constexpr std::u8string_view trim_ascii_blank_right(std::u8string_view str)
+constexpr std::u8string_view trim_cpp_whitespace_right(std::u8string_view str)
 {
     for (std::size_t length = str.size(); length > 0; --length) {
-        if (!is_ascii_blank(str[length - 1])) {
+        if (!is_cpp_whitespace(str[length - 1])) {
             return str.substr(0, length);
         }
     }
     return {};
 }
 
-/// @brief Equivalent to `trim_ascii_blank_right(trim_ascii_blank_left(str))`.
 [[nodiscard]]
-constexpr std::u8string_view trim_ascii_blank(std::u8string_view str)
+constexpr std::u8string_view trim_cpp_whitespace(std::u8string_view str)
 {
-    return trim_ascii_blank_right(trim_ascii_blank_left(str));
+    return trim_cpp_whitespace_right(trim_cpp_whitespace_left(str));
 }
 
 /// @brief Returns `true` if `str` is a valid HTML tag identifier.

--- a/src/main/cpp/cpp.cpp
+++ b/src/main/cpp/cpp.cpp
@@ -378,7 +378,7 @@ namespace {
 [[nodiscard]]
 constexpr bool is_d_char(char8_t c)
 {
-    return is_ascii(c) && !is_ascii_blank(c) && c != u8'(' && c != u8')' && c != '\\';
+    return is_ascii(c) && !is_cpp_whitespace(c) && c != u8'(' && c != u8')' && c != '\\';
 }
 
 [[nodiscard]]

--- a/src/main/cpp/mmml.cpp
+++ b/src/main/cpp/mmml.cpp
@@ -288,7 +288,7 @@ private:
 
     std::size_t match_whitespace()
     {
-        constexpr bool (*predicate)(char8_t) = is_ascii_whitespace;
+        constexpr bool (*predicate)(char8_t) = is_html_whitespace;
         return match_char_sequence(predicate);
     }
 

--- a/src/main/cpp/parse_utils.cpp
+++ b/src/main/cpp/parse_utils.cpp
@@ -37,7 +37,7 @@ Blank_Line find_blank_line_sequence // NOLINT(bugprone-exception-escape)
                 state = State::blank;
                 blank_end = i + 1;
             }
-            else if (!is_ascii_whitespace(str[i])) {
+            else if (!is_html_whitespace(str[i])) {
                 state = State::not_blank;
             }
             continue;
@@ -53,7 +53,7 @@ Blank_Line find_blank_line_sequence // NOLINT(bugprone-exception-escape)
             if (str[i] == u8'\n') {
                 blank_end = i + 1;
             }
-            else if (!is_ascii_whitespace(str[i])) {
+            else if (!is_html_whitespace(str[i])) {
                 return { .begin = blank_begin, .length = blank_end - blank_begin };
             }
             continue;

--- a/src/test/cpp/test_chars_strings.cpp
+++ b/src/test/cpp/test_chars_strings.cpp
@@ -180,28 +180,28 @@ TEST(Charsets, all_ascii_alphanumeric)
 TEST(Charsets, all_ascii_whitespace8)
 {
     for (char8_t c = 0; c < 128; ++c) {
-        EXPECT_EQ(contains(all_ascii_whitespace8, c), is_ascii_whitespace(c));
+        EXPECT_EQ(contains(all_ascii_whitespace8, c), is_html_whitespace(c));
     }
 }
 
 TEST(Charsets, all_ascii_whitespace)
 {
     for (char32_t c = 0; c < 128; ++c) {
-        EXPECT_EQ(contains(all_ascii_whitespace, c), is_ascii_whitespace(c));
+        EXPECT_EQ(contains(all_ascii_whitespace, c), is_html_whitespace(c));
     }
 }
 
-TEST(Charsets, all_ascii_blank8)
+TEST(Charsets, all_cpp_whitespace8)
 {
     for (char8_t c = 0; c < 128; ++c) {
-        EXPECT_EQ(contains(all_ascii_blank8, c), is_ascii_blank(c));
+        EXPECT_EQ(contains(all_cpp_whitespace8, c), is_cpp_whitespace(c));
     }
 }
 
-TEST(Charsets, all_ascii_blank)
+TEST(Charsets, all_cpp_whitespace)
 {
     for (char32_t c = 0; c < 128; ++c) {
-        EXPECT_EQ(contains(all_ascii_blank, c), is_ascii_blank(c));
+        EXPECT_EQ(contains(all_cpp_whitespace, c), is_cpp_whitespace(c));
     }
 }
 
@@ -219,28 +219,28 @@ TEST(Charsets, all_mmml_escapeable)
     }
 }
 
-TEST(Strings, trim_ascii_blank_left)
+TEST(Strings, trim_cpp_whitespace_left)
 {
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank_left(u8"awoo"));
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank_left(u8"\n\t\v\f\r awoo"));
-    EXPECT_EQ(u8"awoo\n\t\v\f\r "sv, trim_ascii_blank_left(u8"awoo\n\t\v\f\r "));
-    EXPECT_EQ(u8"awoo\n\t\v\f\r "sv, trim_ascii_blank_left(u8"\n\t\v\f\r awoo\n\t\v\f\r "));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace_left(u8"awoo"));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace_left(u8"\n\t\v\f\r awoo"));
+    EXPECT_EQ(u8"awoo\n\t\v\f\r "sv, trim_cpp_whitespace_left(u8"awoo\n\t\v\f\r "));
+    EXPECT_EQ(u8"awoo\n\t\v\f\r "sv, trim_cpp_whitespace_left(u8"\n\t\v\f\r awoo\n\t\v\f\r "));
 }
 
-TEST(Strings, trim_ascii_blank_right)
+TEST(Strings, trim_cpp_whitespace_right)
 {
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank_right(u8"awoo"));
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank_right(u8"awoo\n\t\v\f\r "));
-    EXPECT_EQ(u8"\n\t\v\f\r awoo"sv, trim_ascii_blank_right(u8"\n\t\v\f\r awoo"));
-    EXPECT_EQ(u8"\n\t\v\f\r awoo"sv, trim_ascii_blank_right(u8"\n\t\v\f\r awoo\n\t\v\f\r "));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace_right(u8"awoo"));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace_right(u8"awoo\n\t\v\f\r "));
+    EXPECT_EQ(u8"\n\t\v\f\r awoo"sv, trim_cpp_whitespace_right(u8"\n\t\v\f\r awoo"));
+    EXPECT_EQ(u8"\n\t\v\f\r awoo"sv, trim_cpp_whitespace_right(u8"\n\t\v\f\r awoo\n\t\v\f\r "));
 }
 
-TEST(Strings, trim_ascii_blank)
+TEST(Strings, trim_cpp_whitespace)
 {
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank(u8"awoo"));
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank(u8"awoo\n\t\v\f\r "));
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank(u8"\n\t\v\f\r awoo"));
-    EXPECT_EQ(u8"awoo"sv, trim_ascii_blank(u8"\n\t\v\f\r awoo\n\t\v\f\r "));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace(u8"awoo"));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace(u8"awoo\n\t\v\f\r "));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace(u8"\n\t\v\f\r awoo"));
+    EXPECT_EQ(u8"awoo"sv, trim_cpp_whitespace(u8"\n\t\v\f\r awoo\n\t\v\f\r "));
 }
 
 TEST(Strings, is_html_tag_name)


### PR DESCRIPTION
After #4 was merged, there was still some leftover cleanup necessary in `chars.hpp`.

This PR cleans up `chars.hpp` so all the character test functions are neatly sorted by language. `is_ascii_whitespace` and `is_ascii_blank` have been removed for subjectivity. I'm not sure if there's actually a definition of "ASCII whitespace".

In any case, each language has its own notion of what constitutes whitespace, so there should always be a language-specific function to avoid confusion.