### PR TITLE
[cpp] Highlighting granularity improvements

### DIFF
--- a/include/ulight/impl/chars.hpp
+++ b/include/ulight/impl/chars.hpp
@@ -693,6 +693,59 @@ constexpr bool is_cpp_whitespace(char32_t c)
     return c == u8'\t' || c == u8'\n' || c == u8'\f' || c == u8'\r' || c == u8' ' || c == U'\v';
 }
 
+/// @brief Returns `true` iff `c` is in the
+/// [basic character set](https://eel.is/c++draft/tab:lex.charset.basic).
+[[nodiscard]]
+constexpr bool is_cpp_basic(char8_t c)
+{
+    switch (c) {
+    case u8'\t':
+    case u8'\v':
+    case u8'\f':
+    case u8'\r':
+    case u8'\n':
+    case u8'!':
+    case u8'"':
+    case u8'#':
+    case u8'$':
+    case u8'%':
+    case u8'&':
+    case u8'\'':
+    case u8'(':
+    case u8')':
+    case u8'*':
+    case u8'+':
+    case u8',':
+    case u8'-':
+    case u8'.':
+    case u8'/':
+    case u8':':
+    case u8';':
+    case u8'<':
+    case u8'>':
+    case u8'=':
+    case u8'?':
+    case u8'@':
+    case u8'[':
+    case u8']':
+    case u8'\\':
+    case u8'^':
+    case u8'_':
+    case u8'`':
+    case u8'{':
+    case u8'|':
+    case u8'}':
+    case u8'~': return true;
+    default: return is_ascii_alphanumeric(c);
+    }
+}
+
+[[nodiscard]]
+constexpr bool is_cpp_basic(char32_t c)
+{
+    return is_ascii(c) && is_cpp_basic(char8_t(c));
+}
+
 // LUA =============================================================================================
 
 [[nodiscard]]

--- a/include/ulight/impl/cpp.hpp
+++ b/include/ulight/impl/cpp.hpp
@@ -411,7 +411,7 @@ struct Escape_Result {
     /// For example, there can be unterminated `\\o{...` escapes,
     /// `\\u{...}` escapes whose contents are not valid,
     /// `\\U` escapes where one of the following 8 characters is not a hexadecimal digit,
-    /// and other such cases. 
+    /// and other such cases.
     bool erroneous = false;
 
     [[nodiscard]]
@@ -433,26 +433,6 @@ struct Escape_Result {
 /// returns zero.
 [[nodiscard]]
 Escape_Result match_escape_sequence(std::u8string_view str);
-
-struct String_Literal_Result {
-    std::size_t length;
-    std::size_t encoding_prefix_length;
-    bool raw;
-    bool terminated;
-
-    [[nodiscard]]
-    constexpr explicit operator bool() const noexcept
-    {
-        return length != 0;
-    }
-};
-
-/// @brief Matches a C++
-/// *[string-literal](https://eel.is/c++draft/lex#nt:string-literal)*
-/// at the start of `str`.
-/// Returns zero if noe could be matched.
-[[nodiscard]]
-String_Literal_Result match_string_literal(std::u8string_view str);
 
 /// @brief Matches a C or C++
 /// *[preprocessing-op-or-punc](https://eel.is/c++draft/lex#nt:preprocessing-op-or-punc)*

--- a/include/ulight/impl/platform.h
+++ b/include/ulight/impl/platform.h
@@ -20,6 +20,10 @@
 #define ULIGHT_CLANG __clang__
 #endif
 
+#if defined(__GNUC__) && !defined(__clang__)
+#define ULIGHT_GCC __GNUC__
+#endif
+
 #ifdef _MSC_VER
 #define ULIGHT_MSVC _MSC_VER
 #endif
@@ -52,6 +56,13 @@ using Underlying = unsigned char;
 #define ULIGHT_EXPORT EMSCRIPTEN_KEEPALIVE
 #else
 #define ULIGHT_EXPORT
+#endif
+
+#ifdef ULIGHT_GCC
+#define ULIGHT_SUPPRESS_MISSING_DECLARATIONS_WARNING()                                             \
+    _Pragma("GCC diagnostic ignored \"-Wmissing-declarations\"")
+#else
+#define ULIGHT_SUPPRESS_MISSING_DECLARATIONS_WARNING()
 #endif
 
 #endif

--- a/include/ulight/impl/unicode.hpp
+++ b/include/ulight/impl/unicode.hpp
@@ -70,14 +70,15 @@ public:
 /// @brief Returns the length of the UTF-8 unit sequence (including `c`)
 /// that is encoded when `c` is the first unit in that sequence.
 ///
-/// Returns `0` if `c` is not a valid leading code unit,
+/// Returns `fallback` if `c` is not a valid leading code unit,
 /// such as if it begins with `10` or `111110`.
 [[nodiscard]]
-constexpr int sequence_length(char8_t c) noexcept
+constexpr int sequence_length(char8_t c, int fallback = 0) noexcept
 {
+    /// @brief `{ 1, 0, 2, 3, 4, 0... }`
     constexpr unsigned long lookup = 0b100'011'010'000'001;
     const int leading_ones = std::countl_one(static_cast<unsigned char>(c));
-    return leading_ones > 4 ? 0 : int((lookup >> (leading_ones * 3)) & 0x7);
+    return leading_ones > 4 ? fallback : int((lookup >> (leading_ones * 3)) & 0b111);
 }
 
 struct Code_Point_And_Length {

--- a/src/test/cpp/test_cpp.cpp
+++ b/src/test/cpp/test_cpp.cpp
@@ -1,8 +1,23 @@
+#include <iostream>
+
 #include <gtest/gtest.h>
 
 #include "ulight/impl/cpp.hpp"
 
 namespace ulight::cpp {
+
+// NOLINTNEXTLINE(misc-use-internal-linkage)
+std::ostream& operator<<(std::ostream& out, Escape_Type type)
+{
+    return out << int(type);
+}
+
+[[maybe_unused]]
+std::ostream& operator<<(std::ostream& out, Escape_Result result) // NOLINT
+{
+    return out << "{ .length = " << result.length << ", .type = " << result.type << " }";
+}
+
 namespace {
 
 TEST(Cpp, match_pp_number)
@@ -22,6 +37,70 @@ TEST(Cpp, match_pp_number)
 
     EXPECT_EQ(match_pp_number(u8"0e-3"), 4);
     EXPECT_EQ(match_pp_number(u8"0E+3"), 4);
+}
+
+TEST(Cpp, match_escape_sequence)
+{
+    EXPECT_EQ(match_escape_sequence(u8""), Escape_Result());
+    EXPECT_EQ(match_escape_sequence(u8"x"), Escape_Result());
+
+    EXPECT_EQ(match_escape_sequence(u8"\\'x"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\\"x"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\?x"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\ax"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\bx"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\fx"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\nx"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\rx"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\tx"), Escape_Result(2, Escape_Type::simple));
+    EXPECT_EQ(match_escape_sequence(u8"\\vx"), Escape_Result(2, Escape_Type::simple));
+
+    EXPECT_EQ(match_escape_sequence(u8"\\ \n\n"), Escape_Result(3, Escape_Type::newline));
+    EXPECT_EQ(match_escape_sequence(u8"\\\t\n\n"), Escape_Result(3, Escape_Type::newline));
+    EXPECT_EQ(match_escape_sequence(u8"\\\v\n\n"), Escape_Result(3, Escape_Type::newline));
+    EXPECT_EQ(match_escape_sequence(u8"\\\f\n\n"), Escape_Result(3, Escape_Type::newline));
+    EXPECT_EQ(match_escape_sequence(u8"\\\r\n\n"), Escape_Result(3, Escape_Type::newline));
+    EXPECT_EQ(match_escape_sequence(u8"\\\n\n"), Escape_Result(2, Escape_Type::newline));
+
+    EXPECT_EQ(match_escape_sequence(u8"\\u1234"), Escape_Result(6, Escape_Type::universal));
+    EXPECT_EQ(match_escape_sequence(u8"\\u12345"), Escape_Result(6, Escape_Type::universal));
+
+    EXPECT_EQ(match_escape_sequence(u8"\\U12345678"), Escape_Result(10, Escape_Type::universal));
+    EXPECT_EQ(match_escape_sequence(u8"\\U123456789"), Escape_Result(10, Escape_Type::universal));
+
+    EXPECT_EQ(match_escape_sequence(u8"\\u{}"), Escape_Result(4, Escape_Type::universal));
+    EXPECT_EQ(match_escape_sequence(u8"\\u{0}"), Escape_Result(5, Escape_Type::universal));
+    EXPECT_EQ(
+        match_escape_sequence(u8"\\u{0123456789abcdef}"), Escape_Result(20, Escape_Type::universal)
+    );
+
+    EXPECT_EQ(match_escape_sequence(u8"\\N{}"), Escape_Result(4, Escape_Type::universal));
+    EXPECT_EQ(match_escape_sequence(u8"\\N{DELETE}"), Escape_Result(10, Escape_Type::universal));
+    EXPECT_EQ(
+        match_escape_sequence(u8"\\N{EQUALS SIGN}"), Escape_Result(15, Escape_Type::universal)
+    );
+
+    EXPECT_EQ(match_escape_sequence(u8"\\x0x"), Escape_Result(3, Escape_Type::hexadecimal));
+    EXPECT_EQ(match_escape_sequence(u8"\\xffffx"), Escape_Result(6, Escape_Type::hexadecimal));
+    EXPECT_EQ(match_escape_sequence(u8"\\x{}"), Escape_Result(4, Escape_Type::hexadecimal));
+    EXPECT_EQ(match_escape_sequence(u8"\\x{0}"), Escape_Result(5, Escape_Type::hexadecimal));
+    EXPECT_EQ(
+        match_escape_sequence(u8"\\x{0123456789abcdef}"),
+        Escape_Result(20, Escape_Type::hexadecimal)
+    );
+
+    EXPECT_EQ(match_escape_sequence(u8"\\o{}"), Escape_Result(4, Escape_Type::octal));
+    EXPECT_EQ(match_escape_sequence(u8"\\o{0}"), Escape_Result(5, Escape_Type::octal));
+    EXPECT_EQ(match_escape_sequence(u8"\\o{01234567}"), Escape_Result(12, Escape_Type::octal));
+
+    EXPECT_EQ(match_escape_sequence(u8"\\1x"), Escape_Result(2, Escape_Type::octal));
+    EXPECT_EQ(match_escape_sequence(u8"\\12x"), Escape_Result(3, Escape_Type::octal));
+    EXPECT_EQ(match_escape_sequence(u8"\\123x"), Escape_Result(4, Escape_Type::octal));
+    EXPECT_EQ(match_escape_sequence(u8"\\1234x"), Escape_Result(4, Escape_Type::octal));
+
+    EXPECT_EQ(match_escape_sequence(u8"\\$x"), Escape_Result(2, Escape_Type::conditional));
+    EXPECT_EQ(match_escape_sequence(u8"\\#x"), Escape_Result(2, Escape_Type::conditional));
+    EXPECT_EQ(match_escape_sequence(u8"\\#@"), Escape_Result(2, Escape_Type::conditional));
 }
 
 } // namespace

--- a/src/test/cpp/test_cpp.cpp
+++ b/src/test/cpp/test_cpp.cpp
@@ -3,8 +3,11 @@
 #include <gtest/gtest.h>
 
 #include "ulight/impl/cpp.hpp"
+#include "ulight/impl/platform.h"
 
 namespace ulight::cpp {
+
+ULIGHT_SUPPRESS_MISSING_DECLARATIONS_WARNING()
 
 // NOLINTNEXTLINE(misc-use-internal-linkage)
 std::ostream& operator<<(std::ostream& out, Escape_Type type)

--- a/test/highlight/character_literals.cpp
+++ b/test/highlight/character_literals.cpp
@@ -1,0 +1,10 @@
+''
+'a'
+'\n'
+' \n '
+'\N{'
+u8'x'
+u8'y'
+'z'suffix
+L'w'suffix
+'

--- a/test/highlight/character_literals.cpp.html
+++ b/test/highlight/character_literals.cpp.html
@@ -1,0 +1,10 @@
+<h- data-h=str_dlim>'</h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_dlim>'</h-><h- data-h=str>a</h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_dlim>'</h-><h- data-h=esc>\n</h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_dlim>'</h-><h- data-h=str> </h-><h- data-h=esc>\n</h-><h- data-h=str> </h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_dlim>'</h-><h- data-h=err>\N{</h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_deco>u8</h-><h- data-h=str_dlim>'</h-><h- data-h=str>x</h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_deco>u8</h-><h- data-h=str_dlim>'</h-><h- data-h=str>y</h-><h- data-h=str_dlim>'</h->
+<h- data-h=str_dlim>'</h-><h- data-h=str>z</h-><h- data-h=str_dlim>'</h-><h- data-h=str_deco>suffix</h->
+<h- data-h=str_deco>L</h-><h- data-h=str_dlim>'</h-><h- data-h=str>w</h-><h- data-h=str_dlim>'</h-><h- data-h=str_deco>suffix</h->
+<h- data-h=str_dlim>'</h->

--- a/test/highlight/hello_world.cpp.html
+++ b/test/highlight/hello_world.cpp.html
@@ -5,5 +5,5 @@
 
 <h- data-h=kw_type>int</h-> <h- data-h=id>main</h-><h- data-h=sym_par>(</h-><h- data-h=kw_type>int</h-> <h- data-h=id>argc</h-><h- data-h=sym_punc>,</h-> <h- data-h=kw_type>char</h-><h- data-h=sym_op>*</h-><h- data-h=sym_op>*</h-> <h- data-h=id>argv</h-><h- data-h=sym_par>)</h->
 <h- data-h=sym_brac>{</h->
-    <h- data-h=id>cout</h-> <h- data-h=sym_op>&lt;&lt;</h-> <h- data-h=str>"Hello, world!"</h-> <h- data-h=sym_op>&lt;&lt;</h-> <h- data-h=id>std</h-><h- data-h=sym_op>::</h-><h- data-h=id>endl</h-><h- data-h=sym_punc>;</h->
+    <h- data-h=id>cout</h-> <h- data-h=sym_op>&lt;&lt;</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>Hello, world!</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_op>&lt;&lt;</h-> <h- data-h=id>std</h-><h- data-h=sym_op>::</h-><h- data-h=id>endl</h-><h- data-h=sym_punc>;</h->
 <h- data-h=sym_brac>}</h->

--- a/test/highlight/integers.cpp.html
+++ b/test/highlight/integers.cpp.html
@@ -1,10 +1,10 @@
 <h- data-h=num>0</h->
 <h- data-h=num>123</h->
-<h- data-h=num>0xff</h->
-<h- data-h=num>100'000</h->
-<h- data-h=num>5uz</h->
-<h- data-h=num>100_aa</h->
+<h- data-h=num_deco>0x</h-><h- data-h=num>ff</h->
+<h- data-h=num>100</h-><h- data-h=num_dlim>'</h-><h- data-h=num>000</h->
+<h- data-h=num>5</h-><h- data-h=num_deco>uz</h->
+<h- data-h=num>100</h-><h- data-h=num_deco>_aa</h->
 <h- data-h=num>01</h->
-<h- data-h=num>0b1010</h->
-<h- data-h=num>0b333</h->
-<h- data-h=num>0x1'000'fff</h->
+<h- data-h=num_deco>0b</h-><h- data-h=num>1010</h->
+<h- data-h=num_deco>0b</h-><h- data-h=num>333</h->
+<h- data-h=num_deco>0x</h-><h- data-h=num>1</h-><h- data-h=num_dlim>'</h-><h- data-h=num>000</h-><h- data-h=num_dlim>'</h-><h- data-h=num>fff</h->

--- a/test/highlight/raw_strings.cpp
+++ b/test/highlight/raw_strings.cpp
@@ -1,0 +1,8 @@
+R"()"
+R"(abc)"
+R"abc()abc"
+R"abc(abc)abc"
+R"abc(abc)abc)abc"
+R"abc(abc)abc)abc"
+u8R"()"sv
+R"(

--- a/test/highlight/raw_strings.cpp.html
+++ b/test/highlight/raw_strings.cpp.html
@@ -1,0 +1,9 @@
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"(</h-><h- data-h=str_dlim>)"</h->
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"(</h-><h- data-h=str>abc</h-><h- data-h=str_dlim>)"</h->
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"abc(</h-><h- data-h=str_dlim>)abc"</h->
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"abc(</h-><h- data-h=str>abc</h-><h- data-h=str_dlim>)abc"</h->
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"abc(</h-><h- data-h=str>abc)abc</h-><h- data-h=str_dlim>)abc"</h->
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"abc(</h-><h- data-h=str>abc)abc</h-><h- data-h=str_dlim>)abc"</h->
+<h- data-h=str_deco>u8R</h-><h- data-h=str_dlim>"(</h-><h- data-h=str_dlim>)"</h-><h- data-h=id>sv</h->
+<h- data-h=str_deco>R</h-><h- data-h=str_dlim>"(</h-><h- data-h=str>
+</h->

--- a/test/highlight/string_literals.cpp
+++ b/test/highlight/string_literals.cpp
@@ -1,0 +1,10 @@
+""
+"abc"
+"\n"
+" \n "
+"\N{"
+u8"x"
+u8"y"
+"z"suffix
+L"w"suffix
+"

--- a/test/highlight/string_literals.cpp.html
+++ b/test/highlight/string_literals.cpp.html
@@ -1,0 +1,10 @@
+<h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_dlim>"</h-><h- data-h=str>abc</h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_dlim>"</h-><h- data-h=esc>\n</h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_dlim>"</h-><h- data-h=str> </h-><h- data-h=esc>\n</h-><h- data-h=str> </h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_dlim>"</h-><h- data-h=err>\N{</h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_deco>u8</h-><h- data-h=str_dlim>"</h-><h- data-h=str>x</h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_deco>u8</h-><h- data-h=str_dlim>"</h-><h- data-h=str>y</h-><h- data-h=str_dlim>"</h->
+<h- data-h=str_dlim>"</h-><h- data-h=str>z</h-><h- data-h=str_dlim>"</h-><h- data-h=str_deco>suffix</h->
+<h- data-h=str_deco>L</h-><h- data-h=str_dlim>"</h-><h- data-h=str>w</h-><h- data-h=str_dlim>"</h-><h- data-h=str_deco>suffix</h->
+<h- data-h=str_dlim>"</h->


### PR DESCRIPTION
Closes #54.

After this change, *pp-number*s, *character-literal*s, and *string-literal*s are matched in a way consistent with the format specified in `CONTRIBUTING_GUIDELINES.md`.

For example, `"aw\noo"` is no longer a blob with `string` highlighting, but is divided into `string_delim`, `string`, and `escape` parts.