### PR TITLE
Add ASCII algorithms

### DIFF
--- a/include/ulight/impl/ascii_algorithm.hpp
+++ b/include/ulight/impl/ascii_algorithm.hpp
@@ -1,0 +1,113 @@
+#ifndef ULIGHT_ASCII_ALGORITHM_HPP
+#define ULIGHT_ASCII_ALGORITHM_HPP
+
+#include <string_view>
+
+#include "ulight/impl/assert.hpp"
+
+namespace ulight::ascii {
+
+namespace detail {
+
+template <typename F>
+    requires std::is_invocable_r_v<bool, F, char8_t>
+[[nodiscard]]
+std::size_t
+find_if(std::u8string_view str, std::size_t start, F predicate, bool expected, std::size_t npos)
+{
+    ULIGHT_DEBUG_ASSERT(start <= str.length());
+    for (std::size_t i = start; i < str.length(); ++i) {
+        if (predicate(str[i]) == expected) {
+            return i;
+        }
+    }
+    return npos;
+}
+
+} // namespace detail
+
+/// @brief Returns the position of the first code unit `c` in `str` for which
+/// `predicate(c)` is `true`, in code units.
+/// If none could be found, returns `std::u8string_view::npos`.
+/// @throws Unicode_Error If decoding failed.
+template <typename F>
+    requires std::is_invocable_r_v<bool, F, char32_t>
+[[nodiscard]]
+constexpr std::size_t find_if(std::u8string_view str, F predicate, std::size_t start = 0)
+{
+    return detail::find_if(str, start, predicate, true, std::u8string_view::npos);
+}
+
+/// @brief Returns the position of the first code unit `c` in `str` for which
+/// `predicate(c)` is `false`, in code units.
+/// If none could be found, returns `std::u8string_view::npos`.
+/// @throws Unicode_Error If decoding failed.
+template <typename F>
+    requires std::is_invocable_r_v<bool, F, char32_t>
+[[nodiscard]]
+constexpr std::size_t find_if_not(std::u8string_view str, F predicate, std::size_t start = 0)
+{
+    return detail::find_if(str, start, predicate, false, std::u8string_view::npos);
+}
+
+/// @brief Like `find_if`, but returns `str.length()` instead of `npos`.
+template <typename F>
+    requires std::is_invocable_r_v<bool, F, char32_t>
+[[nodiscard]]
+constexpr std::size_t length_if(std::u8string_view str, F predicate, std::size_t start = 0)
+{
+    return detail::find_if(str, start, predicate, false, str.length());
+}
+
+/// @brief Like `find_if_not`, but returns `str.length()` instead of `npos`.
+template <typename F>
+    requires std::is_invocable_r_v<bool, F, char32_t>
+[[nodiscard]]
+constexpr std::size_t length_if_not(std::u8string_view str, F predicate, std::size_t start = 0)
+{
+    return detail::find_if(str, start, predicate, true, str.length());
+}
+
+/// @brief Like `str.find(delimiter, start)`,
+/// but returns `str.length()` when nothing was found, not `npos`.
+[[nodiscard]]
+constexpr std::size_t
+length_before(std::u8string_view str, char8_t delimiter, std::size_t start = 0) noexcept
+{
+    const std::size_t result = str.find(delimiter, start);
+    return result == std::u8string_view::npos ? str.length() : result;
+}
+
+/// @brief Like `str.find_first_not_of(delimiter, start)`,
+/// but returns `str.length()` when nothing was found, not `npos`.
+[[nodiscard]]
+constexpr std::size_t
+length_before_not(std::u8string_view str, char8_t delimiter, std::size_t start = 0) noexcept
+{
+    const std::size_t result = str.find_first_not_of(delimiter, start);
+    return result == std::u8string_view::npos ? str.length() : result;
+}
+
+/// @brief Like `str.find(delimiter, start) + 1`,
+/// but returns `str.length()` when nothing was found.
+[[nodiscard]]
+constexpr std::size_t
+length_until(std::u8string_view str, char8_t delimiter, std::size_t start = 0) noexcept
+{
+    const std::size_t result = str.find(delimiter, start);
+    return result == std::u8string_view::npos ? str.length() : result + 1;
+}
+
+/// @brief Like `str.find_first_not_of(delimiter) + 1`,
+/// but returns `str.length()` when nothing was found.
+[[nodiscard]]
+constexpr std::size_t
+length_until_not(std::u8string_view str, char8_t delimiter, std::size_t start = 0) noexcept
+{
+    const std::size_t result = str.find_first_not_of(delimiter, start);
+    return result == std::u8string_view::npos ? str.length() : result + 1;
+}
+
+} // namespace ulight::ascii
+
+#endif

--- a/src/main/cpp/lang/bash.cpp
+++ b/src/main/cpp/lang/bash.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <string_view>
 
+#include "ulight/impl/ascii_algorithm.hpp"
 #include "ulight/ulight.hpp"
 
 #include "ulight/impl/highlight.hpp"
@@ -75,10 +76,7 @@ std::size_t match_comment(std::u8string_view str)
 
 std::size_t match_blank(std::u8string_view str)
 {
-    const auto predicate = [](char8_t c) { return is_bash_blank(c); };
-    const auto* const data_end = str.data() + str.size();
-    const auto* const end = std::ranges::find_if_not(str.data(), data_end, predicate);
-    return std::size_t(end - str.data());
+    return ascii::length_if(str, [](char8_t c) { return is_bash_blank(c); });
 }
 
 bool starts_with_substitution(std::u8string_view str)

--- a/src/main/cpp/lang/js.cpp
+++ b/src/main/cpp/lang/js.cpp
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <vector>
 
+#include "ulight/impl/ascii_algorithm.hpp"
 #include "ulight/ulight.hpp"
 
 #include "ulight/impl/assert.hpp"
@@ -415,11 +416,10 @@ std::size_t match_template_substitution(std::u8string_view str)
 
 Digits_Result match_digits(std::u8string_view str, int base)
 {
-    const auto* const data_end = str.data() + str.length();
     bool erroneous = false;
 
     char8_t previous = u8'_';
-    const auto* const it = std::ranges::find_if_not(str.data(), data_end, [&](char8_t c) {
+    const std::size_t length = ascii::length_if(str, [&](char8_t c) {
         if (c == u8'_') {
             erroneous |= previous == u8'_';
             previous = c;
@@ -431,7 +431,6 @@ Digits_Result match_digits(std::u8string_view str, int base)
     });
     erroneous |= previous == u8'_';
 
-    const std::size_t length = it == data_end ? str.length() : std::size_t(it - str.data());
     return { .length = length, .erroneous = erroneous };
 }
 

--- a/src/main/cpp/lang/lua.cpp
+++ b/src/main/cpp/lang/lua.cpp
@@ -6,6 +6,7 @@
 #include <string_view>
 #include <vector>
 
+#include "ulight/impl/ascii_algorithm.hpp"
 #include "ulight/impl/buffer.hpp"
 #include "ulight/impl/highlight.hpp"
 #include "ulight/ulight.hpp"
@@ -82,16 +83,20 @@ std::optional<Lua_Token_Type> lua_token_type_by_code(std::u8string_view code) no
     return Lua_Token_Type(result - token_type_codes);
 }
 
+namespace {
+
+constexpr auto is_lua_whitespace_lambda = [](char8_t c) { return is_lua_whitespace(c); };
+
+} // namespace
+
 std::size_t match_whitespace(std::u8string_view str)
 {
-    constexpr auto predicate = [](char8_t c) { return is_lua_whitespace(c); };
-    return std::size_t(std::ranges::find_if_not(str, predicate) - str.begin());
+    return ascii::length_if(str, is_lua_whitespace_lambda);
 }
 
 std::size_t match_non_whitespace(std::u8string_view str)
 {
-    constexpr auto predicate = [](char8_t c) { return !is_lua_whitespace(c); };
-    return std::size_t(std::ranges::find_if_not(str, predicate) - str.begin());
+    return ascii::length_if_not(str, is_lua_whitespace_lambda);
 }
 
 std::size_t match_line_comment(std::u8string_view s) noexcept

--- a/src/main/cpp/lang/mmml.cpp
+++ b/src/main/cpp/lang/mmml.cpp
@@ -5,6 +5,7 @@
 
 #include "ulight/ulight.hpp"
 
+#include "ulight/impl/ascii_algorithm.hpp"
 #include "ulight/impl/assert.hpp"
 #include "ulight/impl/buffer.hpp"
 #include "ulight/impl/highlight.hpp"
@@ -33,9 +34,7 @@ std::size_t match_argument_name(std::u8string_view str)
 std::size_t match_whitespace(std::u8string_view str)
 {
     constexpr auto predicate = [](char8_t c) { return is_html_whitespace(c); };
-    const auto* const data_end = str.data() + str.size();
-    const auto* const end = std::ranges::find_if_not(str.data(), data_end, predicate);
-    return std::size_t(end - str.data());
+    return ascii::length_if(str, predicate);
 }
 
 bool starts_with_escape_or_directive(std::u8string_view str)

--- a/src/test/cpp/test_html.cpp
+++ b/src/test/cpp/test_html.cpp
@@ -5,14 +5,24 @@
 #include "ulight/impl/lang/html.hpp"
 
 namespace ulight::html {
-namespace {
 
-[[maybe_unused]]
-std::ostream& operator<<(std::ostream& out, Match_Result result) // NOLINT
+std::ostream& operator<<(std::ostream& out, Match_Result result); // NOLINT
+
+std::ostream& operator<<(std::ostream& out, Match_Result result)
 {
     return out << "{ .length = " << result.length
                << ", .terminated = " << (result.terminated ? "true" : "false") << " }";
 }
+
+std::ostream& operator<<(std::ostream& out, End_Tag_Result result); // NOLINT
+
+std::ostream& operator<<(std::ostream& out, End_Tag_Result result)
+{
+    return out << "{ .length = " << result.length //
+               << ", .name_length = " << result.name_length << " }";
+}
+
+namespace {
 
 TEST(HTML, match_whitespace)
 {


### PR DESCRIPTION
`std::u8string_view` is somewhat inconvenient and lacking in features. There are two frequent problems:
- There is no `find_if`, so using predicates from character testing needs `<algorithm>`.
- `std::u8string_view::npos` is often a bad default return value, and we'd like the length of the string instead. This organically happens when substracting a resulting `end()` from `begin()` with `<algorithm>`, but requires special casing when using `std::u8string_view::find` et al.