### PR TITLE
Add more support for `char8_t` in API

### DIFF
--- a/include/ulight/impl/platform.h
+++ b/include/ulight/impl/platform.h
@@ -58,6 +58,24 @@ using Underlying = unsigned char;
 #define ULIGHT_EXPORT
 #endif
 
+// https://stackoverflow.com/q/45762357/5740428
+#define ULIGHT_PRAGMA_STR_IMPL(...) _Pragma(#__VA_ARGS__)
+#define ULIGHT_PRAGMA_STR(...) ULIGHT_PRAGMA_STR_IMPL(__VA_ARGS__)
+
+#ifdef ULIGHT_GCC
+#define ULIGHT_DIAGNOSTIC_PUSH() _Pragma("GCC diagnostic push")
+#define ULIGHT_DIAGNOSTIC_POP() _Pragma("GCC diagnostic pop")
+#define ULIGHT_DIAGNOSTIC_IGNORED(...) ULIGHT_PRAGMA_STR(GCC diagnostic ignored __VA_ARGS__)
+#elif defined(ULIGHT_CLANG)
+#define ULIGHT_DIAGNOSTIC_PUSH() _Pragma("clang diagnostic push")
+#define ULIGHT_DIAGNOSTIC_POP() _Pragma("clang diagnostic pop")
+#define ULIGHT_DIAGNOSTIC_IGNORED(...) ULIGHT_PRAGMA_STR(clang diagnostic ignored __VA_ARGS__)
+#else
+#define ULIGHT_DIAGNOSTIC_PUSH()
+#define ULIGHT_DIAGNOSTIC_POP()
+#define ULIGHT_DIAGNOSTIC_IGNORED(...)
+#endif
+
 #ifdef ULIGHT_GCC
 #define ULIGHT_SUPPRESS_MISSING_DECLARATIONS_WARNING()                                             \
     _Pragma("GCC diagnostic ignored \"-Wmissing-declarations\"")

--- a/include/ulight/ulight.h
+++ b/include/ulight/ulight.h
@@ -6,6 +6,13 @@
 #include <stddef.h>
 #include <stdlib.h>
 
+#ifdef __cpp_char8_t
+#define ULIGHT_HAS_CHAR8 1
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L
+#include <uchar.h>
+#define ULIGHT_HAS_CHAR8 1
+#endif
+
 #ifdef __cplusplus
 #define ULIGHT_NOEXCEPT noexcept
 #else
@@ -33,6 +40,13 @@ typedef struct ulight_string_view {
     const char* text;
     size_t length;
 } ulight_string_view;
+
+#ifdef ULIGHT_HAS_CHAR8
+typedef struct ulight_u8string_view {
+    const char8_t* text;
+    size_t length;
+} ulight_u8string_view;
+#endif
 
 // LANGUAGES
 // =================================================================================================
@@ -78,6 +92,11 @@ typedef enum ulight_lang {
 /// Note that all ulight language names are lower-case.
 ulight_lang ulight_get_lang(const char* name, size_t name_length) ULIGHT_NOEXCEPT;
 
+#ifdef ULIGHT_HAS_CHAR8
+/// @brief Like `ulight_get_lang`, but using `char8_t` instead of `char`.
+ulight_lang ulight_get_lang_u8(const char8_t* name, size_t name_length) ULIGHT_NOEXCEPT;
+#endif
+
 typedef struct ulight_lang_entry {
     /// @brief An ASCII-encoded, lower-case name of the language.
     const char* name;
@@ -93,12 +112,24 @@ extern const ulight_lang_entry ulight_lang_list[];
 /// @brief The size of `ulight_lang_list`, in elements.
 extern const size_t ulight_lang_list_length;
 
-/// @brief An array of "display names" of languages,
-/// indexed by the values of `ulight_lang`.
-///
-/// For example, `ulight_lang_display_names[ULIGHT_LANG_CPP]` is `"C++"`.
-/// Each `ulight_string_view` in this array is null-terminated.
+/// @brief Use `ulight_lang_display_name`.
+ULIGHT_DEPRECATED
 extern const ulight_string_view ulight_lang_display_names[ULIGHT_LANG_COUNT];
+
+/// @brief If `lang` is a valid language other than `ULIGHT_LANG_NONE`,
+/// returns a "display name" for the language.
+/// Otherwise returns a zero-length `ulight_string_view`.
+///
+/// The display name is a human-readable name for the language, and may contain spaces.
+/// For example, `ulight_lang_display_name(ULIGHT_LANG_CPP)` is `"C++"`.
+/// The returned `ulight_string_view` is null-terminated.
+ulight_string_view ulight_lang_display_name(ulight_lang lang) ULIGHT_NOEXCEPT;
+
+#ifdef ULIGHT_HAS_CHAR8
+/// @brief Like `ulight_lang_display_name`,
+/// but returns `ulight_u8string_view`.
+ulight_u8string_view ulight_lang_display_name_u8(ulight_lang lang) ULIGHT_NOEXCEPT;
+#endif
 
 // STATUS AND FLAGS
 // =================================================================================================
@@ -385,14 +416,35 @@ typedef enum ulight_highlight_type {
 
 } ulight_highlight_type;
 
-/// @brief Returns a textual representation made of ASCII characters and underscores of `type`.
-/// This is used as a value in `ulight_tokens_to_html`.
+/// @brief Use `ulight_highlight_type_short_string`.
 ULIGHT_DEPRECATED
 ulight_string_view ulight_highlight_type_id(ulight_highlight_type type) ULIGHT_NOEXCEPT;
 
+/// @brief Returns the long string representation of the highlight type.
+/// This is identical to the enumerator,
+/// without `ULIGHT_HL_`, all lowercase, and with `-` instead of `_`.
+/// The long string is used as a key in ulight themes.
+/// The returned `ulight_string_view` is null-terminated.
 ulight_string_view ulight_highlight_type_long_string(ulight_highlight_type type) ULIGHT_NOEXCEPT;
 
+#ifdef ULIGHT_HAS_CHAR8
+/// @brief Like `ulight_highlight_type_long_string`,
+/// but returns `ulight_u8string_view`.
+ulight_u8string_view ulight_highlight_type_long_string_u8(ulight_highlight_type type
+) ULIGHT_NOEXCEPT;
+#endif
+
+/// @brief Returns a textual representation made of ASCII characters and underscores of `type`.
+/// This is used as a value in `ulight_tokens_to_html`.
+/// The returned `ulight_string_view` is null-terminated.
 ulight_string_view ulight_highlight_type_short_string(ulight_highlight_type type) ULIGHT_NOEXCEPT;
+
+#ifdef ULIGHT_HAS_CHAR8
+/// @brief Like `ulight_highlight_type_short_string`,
+/// but returns `ulight_u8string_view`.
+ulight_u8string_view ulight_highlight_type_short_string_u8(ulight_highlight_type type
+) ULIGHT_NOEXCEPT;
+#endif
 
 typedef struct ulight_token {
     /// @brief The index of the first code point within the source code that has the highlighting.

--- a/include/ulight/ulight.hpp
+++ b/include/ulight/ulight.hpp
@@ -32,16 +32,34 @@ enum struct Lang : Underlying {
     none = ULIGHT_LANG_NONE,
 };
 
+/// See `ulight_get_lang`.
 [[nodiscard]]
 inline Lang get_lang(std::string_view name) noexcept
 {
     return Lang(ulight_get_lang(name.data(), name.length()));
 }
 
+/// See `ulight_get_lang_u8`.
 [[nodiscard]]
 inline Lang get_lang(std::u8string_view name) noexcept
 {
-    return get_lang({ reinterpret_cast<const char*>(name.data()), name.size() });
+    return Lang(ulight_get_lang_u8(name.data(), name.length()));
+}
+
+/// See `ulight_lang_display_name`.
+[[nodiscard]]
+inline std::string_view lang_display_name(Lang lang) noexcept
+{
+    const ulight_string_view result = ulight_lang_display_name(ulight_lang(lang));
+    return { result.text, result.length };
+}
+
+/// See `ulight_lang_display_name_u8`.
+[[nodiscard]]
+inline std::u8string_view lang_display_name_u8(Lang lang) noexcept
+{
+    const ulight_u8string_view result = ulight_lang_display_name_u8(ulight_lang(lang));
+    return { result.text, result.length };
 }
 
 /// See `ulight_status`.
@@ -164,12 +182,17 @@ constexpr Flag operator|(Flag x, Flag y) noexcept
     case id: return long_str;
 #define ULIGHT_HIGHLIGHT_TYPE_SHORT_STRING_CASE(id, long_str, short_str, initializer)              \
     case id: return short_str;
+#define ULIGHT_HIGHLIGHT_TYPE_LONG_STRING_CASE_U8(id, long_str, short_str, initializer)            \
+    case id: return u8##long_str;
+#define ULIGHT_HIGHLIGHT_TYPE_SHORT_STRING_CASE_U8(id, long_str, short_str, initializer)           \
+    case id: return u8##short_str;
 
 /// See `ulight_highlight_type`.
 enum struct Highlight_Type : Underlying {
     ULIGHT_HIGHLIGHT_TYPE_ENUM_DATA(ULIGHT_HIGHLIGHT_TYPE_ENUMERATOR)
 };
 
+/// See `ulight_highlight_type_long_string`.
 [[nodiscard]]
 constexpr std::string_view highlight_type_long_string(Highlight_Type type) noexcept
 {
@@ -180,12 +203,35 @@ constexpr std::string_view highlight_type_long_string(Highlight_Type type) noexc
     return {};
 }
 
+/// See `ulight_highlight_type_long_string_u8`.
+[[nodiscard]]
+constexpr std::u8string_view highlight_type_long_string_u8(Highlight_Type type) noexcept
+{
+    switch (type) {
+        using enum Highlight_Type;
+        ULIGHT_HIGHLIGHT_TYPE_ENUM_DATA(ULIGHT_HIGHLIGHT_TYPE_LONG_STRING_CASE_U8)
+    }
+    return {};
+}
+
+/// See `ulight_highlight_type_short_string`.
 [[nodiscard]]
 constexpr std::string_view highlight_type_short_string(Highlight_Type type) noexcept
 {
     switch (type) {
         using enum Highlight_Type;
         ULIGHT_HIGHLIGHT_TYPE_ENUM_DATA(ULIGHT_HIGHLIGHT_TYPE_SHORT_STRING_CASE)
+    }
+    return {};
+}
+
+/// See `ulight_highlight_type_short_string_u8`.
+[[nodiscard]]
+constexpr std::u8string_view highlight_type_short_string_u8(Highlight_Type type) noexcept
+{
+    switch (type) {
+        using enum Highlight_Type;
+        ULIGHT_HIGHLIGHT_TYPE_ENUM_DATA(ULIGHT_HIGHLIGHT_TYPE_SHORT_STRING_CASE_U8)
     }
     return {};
 }

--- a/src/main/cpp/ulight.cpp
+++ b/src/main/cpp/ulight.cpp
@@ -144,9 +144,30 @@ constexpr ulight_string_view ulight_lang_display_names[ULIGHT_LANG_COUNT] {
 };
 // clang-format on
 
+ULIGHT_DIAGNOSTIC_PUSH()
+ULIGHT_DIAGNOSTIC_IGNORED("-Wdeprecated-declarations")
+
 static_assert(std::ranges::none_of(ulight_lang_display_names, [](ulight_string_view str) {
     return str.length == 0;
 }));
+
+ULIGHT_EXPORT
+ulight_string_view ulight_lang_display_name(ulight_lang lang) noexcept
+{
+    if (lang == ULIGHT_LANG_NONE || int(lang) >= int(ULIGHT_LANG_COUNT)) {
+        return {};
+    }
+    return ulight_lang_display_names[std::size_t(lang)];
+}
+
+ULIGHT_EXPORT
+ulight_u8string_view ulight_lang_display_name_u8(ulight_lang lang) noexcept
+{
+    const ulight_string_view result = ulight_lang_display_name(lang);
+    return { reinterpret_cast<const char8_t*>(result.text), result.length };
+}
+
+ULIGHT_DIAGNOSTIC_POP()
 
 namespace {
 
@@ -172,18 +193,44 @@ ulight_lang ulight_get_lang(const char* name, size_t name_length) noexcept
 }
 
 ULIGHT_EXPORT
+ulight_lang ulight_get_lang_u8(const char8_t* name, size_t name_length) noexcept
+{
+    return ulight_get_lang(reinterpret_cast<const char*>(name), name_length);
+}
+
+ULIGHT_EXPORT
 ulight_string_view ulight_highlight_type_long_string(ulight_highlight_type type) noexcept
 {
-    const std::string_view result
-        = ulight::highlight_type_long_string(ulight::Highlight_Type(type));
+    // While using ulight::highlight_type_short_string would be a bit simpler,
+    // we use the u8 variant to reduce code size.
+    // char can alias char8_t anyway.
+    const std::u8string_view result
+        = ulight::highlight_type_long_string_u8(ulight::Highlight_Type(type));
+    return { reinterpret_cast<const char*>(result.data()), result.size() };
+}
+
+ULIGHT_EXPORT
+ulight_u8string_view ulight_highlight_type_long_string_u8(ulight_highlight_type type) noexcept
+{
+    const std::u8string_view result
+        = ulight::highlight_type_long_string_u8(ulight::Highlight_Type(type));
     return { result.data(), result.size() };
 }
 
 ULIGHT_EXPORT
 ulight_string_view ulight_highlight_type_short_string(ulight_highlight_type type) noexcept
 {
-    const std::string_view result
-        = ulight::highlight_type_short_string(ulight::Highlight_Type(type));
+    // See above for implementation rationale.
+    const std::u8string_view result
+        = ulight::highlight_type_short_string_u8(ulight::Highlight_Type(type));
+    return { reinterpret_cast<const char*>(result.data()), result.size() };
+}
+
+ULIGHT_EXPORT
+ulight_u8string_view ulight_highlight_type_short_string_u8(ulight_highlight_type type) noexcept
+{
+    const std::u8string_view result
+        = ulight::highlight_type_short_string_u8(ulight::Highlight_Type(type));
     return { result.data(), result.size() };
 }
 

--- a/src/test/cpp/test_highlight.cpp
+++ b/src/test/cpp/test_highlight.cpp
@@ -151,13 +151,6 @@ TEST_F(Highlight_Test, file_tests)
     }
 }
 
-[[nodiscard]]
-std::string_view lang_display_name(ulight_lang lang)
-{
-    const auto i = std::size_t(lang);
-    return { ulight_lang_display_names[i].text, ulight_lang_display_names[i].length };
-}
-
 TEST_F(Highlight_Test, exhaustive_one_char)
 {
     Token token_buffer[16];
@@ -187,7 +180,8 @@ TEST_F(Highlight_Test, exhaustive_one_char)
             const Status status = state.source_to_tokens();
             if (status != Status::ok && status != Status::bad_code) {
                 lang_success = false;
-                std::cout << ansi::h_red << "FAIL: " << ansi::reset << lang_display_name(lang) //
+                std::cout << ansi::h_red << "FAIL: " << ansi::reset
+                          << lang_display_name(Lang(lang)) //
                           << ", for" << " U+00" << std::hex << int(source) << std::dec;
                 if (!is_html_ascii_control(source)) {
                     std::cout << " '" << source_view << '\'';
@@ -197,7 +191,8 @@ TEST_F(Highlight_Test, exhaustive_one_char)
         }
 
         if (lang_success) {
-            std::cout << ansi::h_green << "OK: " << ansi::reset << lang_display_name(lang) << '\n';
+            std::cout << ansi::h_green << "OK: " << ansi::reset << lang_display_name(Lang(lang))
+                      << '\n';
         }
         else {
             success = false;
@@ -235,14 +230,15 @@ TEST_F(Highlight_Test, exhaustive_three_chars)
             if (status != Status::ok && status != Status::bad_code) {
                 lang_success = false;
                 std::cout << ansi::h_red << "FAIL: " //
-                          << ansi::reset << lang_display_name(lang) //
+                          << ansi::reset << lang_display_name(Lang(lang)) //
                           << ": " << state.get_error_string() << "\n";
                 break;
             }
         }
 
         if (lang_success) {
-            std::cout << ansi::h_green << "OK: " << ansi::reset << lang_display_name(lang) << '\n';
+            std::cout << ansi::h_green << "OK: " << ansi::reset << lang_display_name(Lang(lang))
+                      << '\n';
         }
         else {
             success = false;


### PR DESCRIPTION
It's come to my attention that `char8_t` is also supported in C since C23, so it makes sense to also support it in the API when that type exists.