### PR TITLE
`Function_Ref` improvements

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks:
   - -cppcoreguidelines-pro-bounds-array-to-pointer-decay
   - -cppcoreguidelines-pro-bounds-constant-array-index
   - -cppcoreguidelines-pro-bounds-pointer-arithmetic
+  - -cppcoreguidelines-pro-type-const-cast
   - -cppcoreguidelines-pro-type-member-init
   - -cppcoreguidelines-pro-type-reinterpret-cast
   - -cppcoreguidelines-pro-type-union-access

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ else(NOT DEFINED EMSCRIPTEN)
             src/test/cpp/test_chars_strings.cpp
             src/test/cpp/test_cpp.cpp
             src/test/cpp/test_css.cpp
+            src/test/cpp/test_function_ref.cpp
             src/test/cpp/test_highlight.cpp
             src/test/cpp/test_html.cpp
             src/test/cpp/test_js.cpp

--- a/examples/c_to_html.c
+++ b/examples/c_to_html.c
@@ -4,7 +4,7 @@
 #include "ulight/ulight.h"
 
 // See below.
-static void on_flush(void*, char* str, size_t length)
+static void on_flush(const void*, char* str, size_t length)
 {
     fwrite(str, 1, length, stdout);
 }

--- a/include/ulight/function_ref.hpp
+++ b/include/ulight/function_ref.hpp
@@ -161,11 +161,14 @@ public:
         }
     }
 
+    ULIGHT_DIAGNOSTIC_PUSH()
+    ULIGHT_DIAGNOSTIC_IGNORED("-Wexceptions")
     constexpr R operator()(Args... args) const noexcept(nothrow)
     {
         ULIGHT_ASSERT(m_invoker);
         return m_invoker(m_entity, std::forward<Args>(args)...);
     }
+    ULIGHT_DIAGNOSTIC_POP()
 
     [[nodiscard]]
     constexpr bool has_value() const noexcept

--- a/include/ulight/function_ref.hpp
+++ b/include/ulight/function_ref.hpp
@@ -51,7 +51,7 @@ private:
         }
         else {
             using Const_F = const std::remove_pointer_t<F>*;
-            F f = const_cast<F>(reinterpret_cast<Const_F>(entity));
+            F f = const_cast<F>(static_cast<Const_F>(entity));
             return R((*f)(std::forward<Args>(args)...));
         }
     }

--- a/include/ulight/function_ref.hpp
+++ b/include/ulight/function_ref.hpp
@@ -104,6 +104,18 @@ public:
         // FIXME: this seems overconstrained
     }
 
+    /// @brief Constructs a `Function_Ref` from non-constant function pointer.
+    ///
+    /// Unlike most other constructors,
+    /// this is not marked `constexpr` because it unconditionally requires the use of
+    /// `reinterpret_cast`.
+    [[nodiscard]]
+    Function_Ref_Base(Function* f) noexcept
+        : m_invoker(&call<Function>)
+        , m_entity(reinterpret_cast<Storage*>(&f))
+    {
+    }
+
     /// @brief Constructs a `Function_Ref` from some callable type.
     ///
     /// If `f` is convertible to `R(*)(Args...)`,

--- a/include/ulight/function_ref.hpp
+++ b/include/ulight/function_ref.hpp
@@ -2,6 +2,7 @@
 #define ULIGHT_FUNCTION_REF_HPP
 
 #include <concepts>
+#include <exception>
 #include <type_traits>
 #include <utility>
 
@@ -161,14 +162,18 @@ public:
         }
     }
 
-    ULIGHT_DIAGNOSTIC_PUSH()
-    ULIGHT_DIAGNOSTIC_IGNORED("-Wexceptions")
     constexpr R operator()(Args... args) const noexcept(nothrow)
     {
-        ULIGHT_ASSERT(m_invoker);
+        if constexpr (nothrow) {
+            if (!m_invoker) {
+                std::terminate();
+            }
+        }
+        else {
+            ULIGHT_ASSERT(m_invoker);
+        }
         return m_invoker(m_entity, std::forward<Args>(args)...);
     }
-    ULIGHT_DIAGNOSTIC_POP()
 
     [[nodiscard]]
     constexpr bool has_value() const noexcept

--- a/include/ulight/impl/buffer.hpp
+++ b/include/ulight/impl/buffer.hpp
@@ -21,8 +21,8 @@ struct Non_Owning_Buffer {
 private:
     value_type* m_buffer;
     std::size_t m_capacity;
-    void* m_flush_data;
-    void (*m_flush)(void*, value_type*, std::size_t);
+    const void* m_flush_data;
+    void (*m_flush)(const void*, value_type*, std::size_t);
     std::size_t m_size = 0;
 
 public:
@@ -30,8 +30,8 @@ public:
     constexpr Non_Owning_Buffer(
         value_type* buffer,
         std::size_t capacity,
-        void* flush_data,
-        void (*flush)(void*, value_type*, std::size_t)
+        const void* flush_data,
+        void (*flush)(const void*, value_type*, std::size_t)
     )
         : m_buffer { buffer }
         , m_capacity { capacity }

--- a/include/ulight/impl/highlighter.hpp
+++ b/include/ulight/impl/highlighter.hpp
@@ -149,8 +149,8 @@ protected:
     [[nodiscard]]
     Non_Owning_Buffer<Token> sub_buffer(std::span<Token> data)
     {
-        constexpr auto flush = +[](void* this_pointer, Token* tokens, std::size_t amount) {
-            auto& self = *static_cast<Highlighter_Base*>(this_pointer);
+        constexpr auto flush = +[](const void* this_pointer, Token* tokens, std::size_t amount) {
+            const auto& self = *static_cast<const Highlighter_Base*>(this_pointer);
             for (std::size_t i = 0; i < amount; ++i) {
                 tokens[i].begin += self.index;
             }

--- a/include/ulight/ulight.h
+++ b/include/ulight/ulight.h
@@ -522,10 +522,10 @@ typedef struct ulight_state {
     /// @brief The length of `token_buffer`.
     size_t token_buffer_length;
     /// @brief  Passed as the first argument into `flush_tokens`.
-    void* flush_tokens_data;
+    const void* flush_tokens_data;
     /// @brief When `token_buffer` is full,
     /// is invoked with `flush_tokens_data`, `token_buffer`, and `token_buffer_length`.
-    void (*flush_tokens)(void*, ulight_token*, size_t);
+    void (*flush_tokens)(const void*, ulight_token*, size_t);
 
     /// @brief For HTML generation, the UTF-8-encoded name of tags.
     const char* html_tag_name;
@@ -541,10 +541,10 @@ typedef struct ulight_state {
     /// @brief The length of `text_buffer`.
     size_t text_buffer_length;
     /// @brief Passed as the first argument into `flush_text`.
-    void* flush_text_data;
+    const void* flush_text_data;
     /// @brief When `text_buffer` is full,
     /// is invoked with `flush_text_data`, `text_buffer`, and `text_buffer_length`.
-    void (*flush_text)(void*, char*, size_t);
+    void (*flush_text)(const void*, char*, size_t);
 
     /// @brief A brief UTF-8-encoded error text.
     const char* error;

--- a/include/ulight/ulight.hpp
+++ b/include/ulight/ulight.hpp
@@ -384,7 +384,7 @@ struct [[nodiscard]] State {
         impl.text_buffer_length = buffer.size();
     }
 
-    void on_flush_text(void* data, void action(void*, char*, std::size_t))
+    void on_flush_text(const void* data, void action(const void*, char*, std::size_t))
     {
         impl.flush_text = action;
         impl.flush_text_data = data;

--- a/src/main/cpp/main.cpp
+++ b/src/main/cpp/main.cpp
@@ -57,9 +57,10 @@ int main(int argc, const char** argv)
     state.set_token_buffer(token_buffer);
     state.set_text_buffer(text_buffer);
 
-    state.on_flush_text(out_file, [](void* file, char* str, std::size_t length) {
-        std::fwrite(str, 1, length, static_cast<std::FILE*>(file));
-    });
+    constexpr auto on_flush_text_lambda = [](std::FILE* file, char* str, std::size_t length) { //
+        std::fwrite(str, 1, length, file);
+    };
+    state.on_flush_text({ Constant<on_flush_text_lambda> {}, out_file });
 
     Status status = state.source_to_html();
     if (status != Status::ok) {

--- a/src/test/cpp/test_function_ref.cpp
+++ b/src/test/cpp/test_function_ref.cpp
@@ -67,7 +67,9 @@ TEST(Function_Ref, from_callable)
         }
     };
 
-    Function_Ref<int(int)> r_dangling = Sqr {};
+    [[maybe_unused]]
+    Function_Ref<int(int)> r_dangling
+        = Sqr {};
 
     Sqr sqr;
     Function_Ref<int(int)> r = sqr;

--- a/src/test/cpp/test_function_ref.cpp
+++ b/src/test/cpp/test_function_ref.cpp
@@ -58,5 +58,42 @@ TEST(Function_Ref, from_constant_with_entity)
     ASSERT_EQ(r_lambda(2), 4 + s);
 }
 
+TEST(Function_Ref, from_callable)
+{
+    struct Sqr {
+        int operator()(int x) const
+        {
+            return x * x;
+        }
+    };
+
+    Function_Ref<int(int)> r_dangling = Sqr {};
+
+    Sqr sqr;
+    Function_Ref<int(int)> r = sqr;
+    ASSERT_EQ(r(2), 4);
+
+    const Sqr sqr_const;
+    Function_Ref<int(int)> cr0 = sqr_const;
+    Function_Ref<int(int) const> cr1 = sqr_const;
+    ASSERT_EQ(cr0(2), 4);
+    ASSERT_EQ(cr1(2), 4);
+
+    static constexpr Sqr sqr_constexpr;
+    constexpr Function_Ref<int(int)> r_constexpr = sqr_constexpr;
+    ASSERT_EQ(r_constexpr(2), 4);
+
+    constexpr auto lambda = [](int x) { return x * x; };
+    Function_Ref<int(int)> cl = lambda;
+    ASSERT_EQ(cl(2), 4);
+
+    int s = 1;
+    const auto lambda_cap = [&](int x) { return (x * x) + s; };
+    Function_Ref<int(int)> cl_cap0 = lambda_cap;
+    Function_Ref<int(int) const> cl_cap1 = lambda_cap;
+    ASSERT_EQ(cl_cap0(2), 5);
+    ASSERT_EQ(cl_cap1(2), 5);
+}
+
 } // namespace
 } // namespace ulight

--- a/src/test/cpp/test_function_ref.cpp
+++ b/src/test/cpp/test_function_ref.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include "ulight/function_ref.hpp"
+
+namespace ulight {
+namespace {
+
+constexpr int sqr(int x) noexcept
+{
+    return x * x;
+}
+
+TEST(Function_Ref, default_construct)
+{
+    [[maybe_unused]]
+    constexpr Function_Ref<void()> a0;
+    [[maybe_unused]]
+    constexpr Function_Ref<void()> a1
+        = {};
+
+    [[maybe_unused]]
+    Function_Ref<void()> b;
+    [[maybe_unused]]
+    Function_Ref<void(int)> c;
+    [[maybe_unused]]
+    Function_Ref<int(void)> d;
+}
+
+TEST(Function_Ref, from_function_pointer)
+{
+    Function_Ref<int(int)> r0 = sqr;
+    ASSERT_EQ(r0(2), 4);
+
+    Function_Ref<int(int) const noexcept> r1 = sqr;
+    ASSERT_EQ(r1(2), 4);
+}
+
+TEST(Function_Ref, from_constant)
+{
+    constexpr Function_Ref<int(int)> r_lambda = Constant<[](int x) { return x * x; }> {};
+    static_assert(r_lambda(2) == 4);
+    ASSERT_EQ(r_lambda(2), 4);
+
+    constexpr Function_Ref<long(int)> r_lambda2 = Constant<[](int x) noexcept { return x * x; }> {};
+    static_assert(r_lambda2(2) == 4);
+    ASSERT_EQ(r_lambda2(2), 4);
+
+    constexpr Function_Ref<int(int)> r_pointer = Constant<&sqr> {};
+    static_assert(r_pointer(2) == 4);
+    ASSERT_EQ(r_pointer(2), 4);
+}
+
+TEST(Function_Ref, from_constant_with_entity)
+{
+    static constexpr int s = 1;
+    constexpr Function_Ref<int(int)> r_lambda
+        = { Constant<[](const int* c, int x) { return (x * x) + *c; }> {}, &s };
+    ASSERT_EQ(r_lambda(2), 4 + s);
+}
+
+} // namespace
+} // namespace ulight


### PR DESCRIPTION
This adds some long-overdue tests for `Function_Ref`. I thought we had some already, but apparently not.

It turns out that some of the constructors were a bit overconstrained.

Also, it really only makes sense to store `const void*` as the "entity" of the `Function_Ref` because arbitrary pointers by the users can be passed in for that. There's nothing wrong with creating a `Function_Ref` which has a `const` entity even though its function type is non-`const`, and vice versa. It's the invoker's job to deal with that.