### PR TITLE
[c++] Fix highlighting of `operator""`

### DIFF
--- a/include/ulight/impl/lang/cowel_chars.hpp
+++ b/include/ulight/impl/lang/cowel_chars.hpp
@@ -135,6 +135,25 @@ constexpr bool is_cowel_allowed_after_backslash(char32_t c) noexcept
     return is_ascii(c) && is_cowel_allowed_after_backslash(char8_t(c));
 }
 
+inline constexpr Charset256 is_cowel_unquoted_string_set
+    = is_cowel_directive_name_set | detail::to_charset256(u8'-');
+
+/// @brief Returns `true` iff `c` can appear in an argument value
+/// without surrounding quotation marks.
+[[nodiscard]]
+constexpr bool is_cowel_unquoted_string(char8_t c) noexcept
+{
+    return is_cowel_unquoted_string_set.contains(c);
+}
+
+/// @brief Returns `true` iff `c` can appear in an argument value
+/// without surrounding quotation marks.
+[[nodiscard]]
+constexpr bool is_cowel_unquoted_string(char32_t c) noexcept
+{
+    return is_ascii(c) && is_cowel_unquoted_string(char8_t(c));
+}
+
 } // namespace ulight
 
 #endif

--- a/test/highlight/cpp/user_defined_literals.cpp
+++ b/test/highlight/cpp/user_defined_literals.cpp
@@ -1,0 +1,4 @@
+int operator""x();
+int operator"" x();
+int operator""_x();
+int operator""if();

--- a/test/highlight/cpp/user_defined_literals.cpp.html
+++ b/test/highlight/cpp/user_defined_literals.cpp.html
@@ -1,0 +1,4 @@
+<h- data-h=kw_type>int</h-> <h- data-h=kw>operator</h-><h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-><h- data-h=str_deco>x</h-><h- data-h=sym_par>(</h-><h- data-h=sym_par>)</h-><h- data-h=sym_punc>;</h->
+<h- data-h=kw_type>int</h-> <h- data-h=kw>operator</h-><h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-> <h- data-h=id>x</h-><h- data-h=sym_par>(</h-><h- data-h=sym_par>)</h-><h- data-h=sym_punc>;</h->
+<h- data-h=kw_type>int</h-> <h- data-h=kw>operator</h-><h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-><h- data-h=str_deco>_x</h-><h- data-h=sym_par>(</h-><h- data-h=sym_par>)</h-><h- data-h=sym_punc>;</h->
+<h- data-h=kw_type>int</h-> <h- data-h=kw>operator</h-><h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-><h- data-h=kw_ctrl>if</h-><h- data-h=sym_par>(</h-><h- data-h=sym_par>)</h-><h- data-h=sym_punc>;</h->


### PR DESCRIPTION
Fixes #109.

`operator` was not recognized as a keyword, but highlighted as an error because it is not a valid string prefix.