### PR TITLE
[javascript] Rename `Lang::javascript` to `Lang::js`

### DIFF
--- a/include/ulight/impl/highlight.hpp
+++ b/include/ulight/impl/highlight.hpp
@@ -96,7 +96,7 @@ inline Status highlight(
         return to_result(highlight_css(out, source, memory, options));
     case Lang::c: //
         return to_result(highlight_c(out, source, memory, options));
-    case Lang::javascript: //
+    case Lang::js: //
         return to_result(highlight_javascript(out, source, memory, options));
     case Lang::bash: //
         return to_result(highlight_bash(out, source, memory, options));

--- a/include/ulight/ulight.hpp
+++ b/include/ulight/ulight.hpp
@@ -25,7 +25,7 @@ enum struct Lang : Underlying {
     diff = ULIGHT_LANG_DIFF,
     ebnf = ULIGHT_LANG_EBNF,
     html = ULIGHT_LANG_HTML,
-    javascript = ULIGHT_LANG_JS,
+    js = ULIGHT_LANG_JS,
     json = ULIGHT_LANG_JSON,
     jsonc = ULIGHT_LANG_JSONC,
     kotlin = ULIGHT_LANG_KOTLIN,

--- a/src/main/cpp/lang/html.cpp
+++ b/src/main/cpp/lang/html.cpp
@@ -406,7 +406,7 @@ private:
         }
         if (equals_ascii_ignore_case(name, script_tag)) {
             const std::size_t js_length = match_raw_text(remainder, script_tag);
-            consume_nested_css_or_js(Lang::javascript, js_length);
+            consume_nested_css_or_js(Lang::js, js_length);
             return true;
         }
         if (equals_ascii_ignore_case(name, style_tag)) {
@@ -420,7 +420,7 @@ private:
 
     void consume_nested_css_or_js(Lang lang, std::size_t length)
     {
-        ULIGHT_ASSERT(lang == Lang::css || lang == Lang::javascript);
+        ULIGHT_ASSERT(lang == Lang::css || lang == Lang::js);
         if (length == 0) {
             return;
         }


### PR DESCRIPTION
Fixes #117.