### PR TITLE
Add TypeScript highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ and a stable numeric ID whose value can be found in `include/ulight.h`.
 | Diff | `diff`, `patch` | `ULIGHT_LANG_DIFF` |
 | EBNF | `ebnf` | `ULIGHT_LANG_EBNF` |
 | HTML | `htm`, `html` | `ULIGHT_LANG_HTML` |
-| JavaScript | `javascript`, `js`, `jsx` | `ULIGHT_LANG_JS` |
+| JavaScript | `javascript`, `js`, `jsx` | `ULIGHT_LANG_JAVASCRIPT` |
 | JSON | `json` | `ULIGHT_LANG_JSON` |
 | JSON with Comments | `jsonc` | `ULIGHT_LANG_JSONC` |
 | LaTeX | `latex` | `ULIGHT_LANG_LATEX` |
@@ -128,6 +128,7 @@ and a stable numeric ID whose value can be found in `include/ulight.h`.
 | Python | `gyp`, `py`, `python` | `ULIGHT_LANG_PYTHON` |
 | TeX | `tex` | `ULIGHT_LANG_TEX` |
 | Plaintext | `plaintext`, `text`, `txt` | `ULIGHT_LANG_TXT` |
+| TypeScript | `ts`, `tsx`, `typescript` | `ULIGHT_LANG_TYPESCRIPT` |
 | XML | `atom`, `plist`, `rss`, `svg`, `xbj`, `xhtml`, `xml`, `xsd`, `xsl` | `ULIGHT_LANG_XML` |
 
 The long-term plan is to get support for at least 100 languages.

--- a/include/ulight/impl/highlight.hpp
+++ b/include/ulight/impl/highlight.hpp
@@ -45,6 +45,7 @@ Highlight_Fn highlight_lua;
 Highlight_Fn highlight_nasm;
 Highlight_Fn highlight_python;
 Highlight_Fn highlight_tex;
+Highlight_Fn highlight_typescript;
 Highlight_Fn highlight_xml;
 
 inline bool highlight_txt(
@@ -74,55 +75,40 @@ inline Status highlight(
     const Highlight_Options& options = {}
 )
 {
-    constexpr auto to_result = [](bool success) -> Status {
-        if (success) {
-            return Status::ok;
-        }
-        return Status::bad_code;
-    };
+    static constexpr auto highlight_functions = [] {
+        std::array<Highlight_Fn*, ULIGHT_LANG_COUNT> result;
+        result[ULIGHT_LANG_BASH] = highlight_bash;
+        result[ULIGHT_LANG_C] = highlight_c;
+        result[ULIGHT_LANG_COWEL] = highlight_cowel;
+        result[ULIGHT_LANG_CPP] = highlight_cpp;
+        result[ULIGHT_LANG_CSS] = highlight_css;
+        result[ULIGHT_LANG_DIFF] = highlight_diff;
+        result[ULIGHT_LANG_EBNF] = highlight_ebnf;
+        result[ULIGHT_LANG_HTML] = highlight_html;
+        result[ULIGHT_LANG_JAVASCRIPT] = highlight_javascript;
+        result[ULIGHT_LANG_JSON] = highlight_json;
+        result[ULIGHT_LANG_JSONC] = highlight_jsonc;
+        result[ULIGHT_LANG_KOTLIN] = highlight_kotlin;
+        result[ULIGHT_LANG_LATEX] = highlight_latex;
+        result[ULIGHT_LANG_LUA] = highlight_lua;
+        result[ULIGHT_LANG_NASM] = highlight_nasm;
+        result[ULIGHT_LANG_NONE] = nullptr;
+        result[ULIGHT_LANG_PYTHON] = highlight_python;
+        result[ULIGHT_LANG_TEX] = highlight_tex;
+        result[ULIGHT_LANG_TXT] = highlight_txt;
+        result[ULIGHT_LANG_TYPESCRIPT] = highlight_typescript;
+        result[ULIGHT_LANG_XML] = highlight_xml;
+        return result;
+    }();
 
-    switch (language) {
-    case Lang::cpp: //
-        return to_result(highlight_cpp(out, source, memory, options));
-    case Lang::cowel: //
-        return to_result(highlight_cowel(out, source, memory, options));
-    case Lang::lua: //
-        return to_result(highlight_lua(out, source, memory, options));
-    case Lang::html: //
-        return to_result(highlight_html(out, source, memory, options));
-    case Lang::xml: //
-        return to_result(highlight_xml(out, source, memory, options));
-    case Lang::css: //
-        return to_result(highlight_css(out, source, memory, options));
-    case Lang::c: //
-        return to_result(highlight_c(out, source, memory, options));
-    case Lang::js: //
-        return to_result(highlight_javascript(out, source, memory, options));
-    case Lang::bash: //
-        return to_result(highlight_bash(out, source, memory, options));
-    case Lang::diff: //
-        return to_result(highlight_diff(out, source, memory, options));
-    case Lang::json: //
-        return to_result(highlight_json(out, source, memory, options));
-    case Lang::jsonc: //
-        return to_result(highlight_jsonc(out, source, memory, options));
-    case Lang::txt: //
-        return to_result(highlight_txt(out, source, memory, options));
-    case Lang::tex: //
-        return to_result(highlight_tex(out, source, memory, options));
-    case Lang::latex: //
-        return to_result(highlight_latex(out, source, memory, options));
-    case Lang::nasm: //
-        return to_result(highlight_nasm(out, source, memory, options));
-    case Lang::ebnf: //
-        return to_result(highlight_ebnf(out, source, memory, options));
-    case Lang::python: //
-        return to_result(highlight_python(out, source, memory, options));
-    case Lang::kotlin: //
-        return to_result(highlight_kotlin(out, source, memory, options));
-    default: //
+    if (int(language) >= ULIGHT_LANG_COUNT) {
         return Status::bad_lang;
     }
+    Highlight_Fn* const highlighter = highlight_functions[std::size_t(language)];
+    if (!highlighter) {
+        return Status::bad_lang;
+    }
+    return highlighter(out, source, memory, options) ? Status::ok : Status::bad_code;
 }
 
 } // namespace ulight

--- a/include/ulight/impl/lang/js.hpp
+++ b/include/ulight/impl/lang/js.hpp
@@ -13,118 +13,138 @@
 namespace ulight::js {
 
 enum struct Feature_Source : Underlying {
-    /// @brief Common JavaScript
-    js,
+    /// @brief JavaScript
+    js = 0b001,
+    /// @brief TypeScript
+    ts = 0b010,
     /// @brief JSX features
-    jsx,
+    jsx = 0b100,
+    /// @brief Common between JavaScript and TypeScript
+    js_ts = js | ts,
     /// @brief Common between JavaScript and JSX
-    js_jsx,
+    js_jsx = js | jsx,
+    /// @brief Common between TypeScript and JSX
+    ts_jsx = ts | jsx,
+    /// @brief Common between JavaScript, TypeScript, and JSX
+    all = js | ts | jsx,
 };
 
 #define ULIGHT_JS_TOKEN_ENUM_DATA(F)                                                               \
-    F(logical_not, "!", sym_op, js)                                                                \
-    F(not_equals, "!=", sym_op, js)                                                                \
-    F(strict_not_equals, "!==", sym_op, js)                                                        \
-    F(modulo, "%", sym_op, js)                                                                     \
-    F(modulo_equal, "%=", sym_op, js)                                                              \
-    F(bitwise_and, "&", sym_op, js)                                                                \
-    F(logical_and, "&&", sym_op, js)                                                               \
-    F(logical_and_equal, "&&=", sym_op, js)                                                        \
-    F(bitwise_and_equal, "&=", sym_op, js)                                                         \
-    F(left_paren, "(", sym_parens, js_jsx)                                                         \
-    F(right_paren, ")", sym_parens, js_jsx)                                                        \
-    F(multiply, "*", sym_op, js)                                                                   \
-    F(exponentiation, "**", sym_op, js)                                                            \
-    F(exponentiation_equal, "**=", sym_op, js)                                                     \
-    F(multiply_equal, "*=", sym_op, js)                                                            \
-    F(plus, "+", sym_op, js)                                                                       \
-    F(increment, "++", sym_op, js)                                                                 \
-    F(plus_equal, "+=", sym_op, js)                                                                \
-    F(comma, ",", sym_punc, js_jsx)                                                                \
-    F(minus, "-", sym_op, js)                                                                      \
-    F(decrement, "--", sym_op, js)                                                                 \
-    F(minus_equal, "-=", sym_op, js)                                                               \
-    F(dot, ".", sym_op, js_jsx)                                                                    \
-    F(ellipsis, "...", sym_op, js_jsx)                                                             \
-    F(divide, "/", sym_op, js)                                                                     \
-    F(divide_equal, "/=", sym_op, js)                                                              \
-    F(colon, ":", sym_op, js_jsx)                                                                  \
-    F(semicolon, ";", sym_punc, js_jsx)                                                            \
-    F(less_than, "<", sym_op, js_jsx)                                                              \
-    F(left_shift, "<<", sym_op, js)                                                                \
-    F(left_shift_equal, "<<=", sym_op, js)                                                         \
-    F(less_equal, "<=", sym_op, js)                                                                \
-    F(assignment, "=", sym_op, js)                                                                 \
-    F(equals, "==", sym_op, js)                                                                    \
-    F(strict_equals, "===", sym_op, js)                                                            \
-    F(arrow, "=>", sym_op, js)                                                                     \
-    F(greater_than, ">", sym_op, js)                                                               \
-    F(greater_equal, ">=", sym_op, js)                                                             \
-    F(right_shift, ">>", sym_op, js)                                                               \
-    F(right_shift_equal, ">>=", sym_op, js)                                                        \
-    F(unsigned_right_shift, ">>>", sym_op, js)                                                     \
-    F(unsigned_right_shift_equal, ">>>=", sym_op, js)                                              \
-    F(conditional, "?", sym_op, js)                                                                \
-    F(optional_chaining, "?.", sym_op, js)                                                         \
-    F(nullish_coalescing, "??", sym_op, js)                                                        \
-    F(nullish_coalescing_equal, "??=", sym_op, js)                                                 \
-    F(left_bracket, "[", sym_square, js_jsx)                                                       \
-    F(right_bracket, "]", sym_square, js_jsx)                                                      \
-    F(bitwise_xor, "^", sym_op, js)                                                                \
-    F(bitwise_xor_equal, "^=", sym_op, js)                                                         \
-    F(kw_as, "as", keyword, js)                                                                    \
-    F(kw_async, "async", keyword, js)                                                              \
-    F(kw_await, "await", keyword, js)                                                              \
-    F(kw_break, "break", keyword_control, js)                                                      \
-    F(kw_case, "case", keyword_control, js)                                                        \
-    F(kw_catch, "catch", keyword_control, js)                                                      \
-    F(kw_class, "class", keyword, js)                                                              \
-    F(kw_const, "const", keyword, js)                                                              \
-    F(kw_continue, "continue", keyword_control, js)                                                \
-    F(kw_debugger, "debugger", keyword, js)                                                        \
-    F(kw_default, "default", keyword_control, js)                                                  \
-    F(kw_delete, "delete", keyword, js)                                                            \
-    F(kw_do, "do", keyword_control, js)                                                            \
-    F(kw_else, "else", keyword_control, js)                                                        \
-    F(kw_enum, "enum", keyword, js)                                                                \
-    F(kw_export, "export", keyword, js)                                                            \
-    F(kw_extends, "extends", keyword, js)                                                          \
-    F(kw_false, "false", bool_, js)                                                                \
-    F(kw_finally, "finally", keyword_control, js)                                                  \
-    F(kw_for, "for", keyword_control, js)                                                          \
-    F(kw_from, "from", keyword, js)                                                                \
-    F(kw_function, "function", keyword, js)                                                        \
-    F(kw_get, "get", keyword, js)                                                                  \
-    F(kw_if, "if", keyword_control, js)                                                            \
-    F(kw_import, "import", keyword, js)                                                            \
-    F(kw_in, "in", keyword, js)                                                                    \
-    F(kw_instanceof, "instanceof", keyword, js)                                                    \
-    F(kw_let, "let", keyword, js)                                                                  \
-    F(kw_new, "new", keyword, js)                                                                  \
-    F(kw_null, "null", null, js)                                                                   \
-    F(kw_of, "of", keyword, js)                                                                    \
-    F(kw_return, "return", keyword_control, js)                                                    \
-    F(kw_set, "set", keyword, js)                                                                  \
-    F(kw_static, "static", keyword, js)                                                            \
-    F(kw_super, "super", keyword, js)                                                              \
-    F(kw_switch, "switch", keyword_control, js)                                                    \
-    F(kw_this, "this", this_, js)                                                                  \
-    F(kw_throw, "throw", keyword_control, js)                                                      \
-    F(kw_true, "true", bool_, js)                                                                  \
-    F(kw_try, "try", keyword_control, js)                                                          \
-    F(kw_typeof, "typeof", keyword, js)                                                            \
-    F(kw_var, "var", keyword, js)                                                                  \
-    F(kw_void, "void", keyword, js)                                                                \
-    F(kw_while, "while", keyword_control, js)                                                      \
-    F(kw_with, "with", keyword_control, js)                                                        \
-    F(kw_yield, "yield", keyword, js)                                                              \
-    F(left_brace, "{", sym_brace, js_jsx)                                                          \
-    F(bitwise_or, "|", sym_op, js)                                                                 \
-    F(bitwise_or_equal, "|=", sym_op, js)                                                          \
-    F(logical_or, "||", sym_op, js)                                                                \
-    F(logical_or_equal, "||=", sym_op, js)                                                         \
-    F(right_brace, "}", sym_brace, js_jsx)                                                         \
-    F(bitwise_not, "~", sym_op, js)
+    F(logical_not, "!", sym_op, js_ts)                                                             \
+    F(not_equals, "!=", sym_op, js_ts)                                                             \
+    F(strict_not_equals, "!==", sym_op, js_ts)                                                     \
+    F(modulo, "%", sym_op, js_ts)                                                                  \
+    F(modulo_equal, "%=", sym_op, js_ts)                                                           \
+    F(bitwise_and, "&", sym_op, js_ts)                                                             \
+    F(logical_and, "&&", sym_op, js_ts)                                                            \
+    F(logical_and_equal, "&&=", sym_op, js_ts)                                                     \
+    F(bitwise_and_equal, "&=", sym_op, js_ts)                                                      \
+    F(left_paren, "(", sym_parens, all)                                                            \
+    F(right_paren, ")", sym_parens, all)                                                           \
+    F(multiply, "*", sym_op, js_ts)                                                                \
+    F(exponentiation, "**", sym_op, js_ts)                                                         \
+    F(exponentiation_equal, "**=", sym_op, js_ts)                                                  \
+    F(multiply_equal, "*=", sym_op, js_ts)                                                         \
+    F(plus, "+", sym_op, js_ts)                                                                    \
+    F(increment, "++", sym_op, js_ts)                                                              \
+    F(plus_equal, "+=", sym_op, js_ts)                                                             \
+    F(comma, ",", sym_punc, all)                                                                   \
+    F(minus, "-", sym_op, js_ts)                                                                   \
+    F(decrement, "--", sym_op, js_ts)                                                              \
+    F(minus_equal, "-=", sym_op, js_ts)                                                            \
+    F(dot, ".", sym_op, all)                                                                       \
+    F(ellipsis, "...", sym_op, all)                                                                \
+    F(divide, "/", sym_op, js_ts)                                                                  \
+    F(divide_equal, "/=", sym_op, js_ts)                                                           \
+    F(colon, ":", sym_op, all)                                                                     \
+    F(semicolon, ";", sym_punc, all)                                                               \
+    F(less_than, "<", sym_op, all)                                                                 \
+    F(left_shift, "<<", sym_op, js_ts)                                                             \
+    F(left_shift_equal, "<<=", sym_op, js_ts)                                                      \
+    F(less_equal, "<=", sym_op, js_ts)                                                             \
+    F(assignment, "=", sym_op, js_ts)                                                              \
+    F(equals, "==", sym_op, js_ts)                                                                 \
+    F(strict_equals, "===", sym_op, js_ts)                                                         \
+    F(arrow, "=>", sym_op, js_ts)                                                                  \
+    F(greater_than, ">", sym_op, js_ts)                                                            \
+    F(greater_equal, ">=", sym_op, js_ts)                                                          \
+    F(right_shift, ">>", sym_op, js_ts)                                                            \
+    F(right_shift_equal, ">>=", sym_op, js_ts)                                                     \
+    F(unsigned_right_shift, ">>>", sym_op, js_ts)                                                  \
+    F(unsigned_right_shift_equal, ">>>=", sym_op, js_ts)                                           \
+    F(conditional, "?", sym_op, js_ts)                                                             \
+    F(optional_chaining, "?.", sym_op, js_ts)                                                      \
+    F(nullish_coalescing, "??", sym_op, js_ts)                                                     \
+    F(nullish_coalescing_equal, "??=", sym_op, js_ts)                                              \
+    F(at, "@", sym_punc, ts)                                                                       \
+    F(left_bracket, "[", sym_square, all)                                                          \
+    F(right_bracket, "]", sym_square, all)                                                         \
+    F(bitwise_xor, "^", sym_op, js_ts)                                                             \
+    F(bitwise_xor_equal, "^=", sym_op, js_ts)                                                      \
+    F(kw_any, "any", keyword_type, ts)                                                             \
+    F(kw_as, "as", keyword, js_ts)                                                                 \
+    F(kw_asserts, "asserts", keyword, ts)                                                          \
+    F(kw_async, "async", keyword, js_ts)                                                           \
+    F(kw_await, "await", keyword, js_ts)                                                           \
+    F(kw_boolean, "boolean", keyword_type, ts)                                                     \
+    F(kw_break, "break", keyword_control, js_ts)                                                   \
+    F(kw_case, "case", keyword_control, js_ts)                                                     \
+    F(kw_catch, "catch", keyword_control, js_ts)                                                   \
+    F(kw_class, "class", keyword, js_ts)                                                           \
+    F(kw_const, "const", keyword, js_ts)                                                           \
+    F(kw_constructor, "constructor", keyword, ts)                                                  \
+    F(kw_continue, "continue", keyword_control, js_ts)                                             \
+    F(kw_debugger, "debugger", keyword, js_ts)                                                     \
+    F(kw_default, "default", keyword_control, js_ts)                                               \
+    F(kw_delete, "delete", keyword, js_ts)                                                         \
+    F(kw_do, "do", keyword_control, js_ts)                                                         \
+    F(kw_else, "else", keyword_control, js_ts)                                                     \
+    F(kw_enum, "enum", keyword, js_ts)                                                             \
+    F(kw_export, "export", keyword, js_ts)                                                         \
+    F(kw_extends, "extends", keyword, js_ts)                                                       \
+    F(kw_false, "false", bool_, js_ts)                                                             \
+    F(kw_finally, "finally", keyword_control, js_ts)                                               \
+    F(kw_for, "for", keyword_control, js_ts)                                                       \
+    F(kw_from, "from", keyword, js_ts)                                                             \
+    F(kw_function, "function", keyword, js_ts)                                                     \
+    F(kw_get, "get", keyword, js_ts)                                                               \
+    F(kw_if, "if", keyword_control, js_ts)                                                         \
+    F(kw_implements, "implements", keyword, ts)                                                    \
+    F(kw_import, "import", keyword, js_ts)                                                         \
+    F(kw_in, "in", keyword, js_ts)                                                                 \
+    F(kw_instanceof, "instanceof", keyword, js_ts)                                                 \
+    F(kw_interface, "interface", keyword, ts)                                                      \
+    F(kw_is, "is", keyword, ts)                                                                    \
+    F(kw_let, "let", keyword, js_ts)                                                               \
+    F(kw_new, "new", keyword, js_ts)                                                               \
+    F(kw_null, "null", null, js_ts)                                                                \
+    F(kw_of, "of", keyword, js_ts)                                                                 \
+    F(kw_private, "private", keyword, ts)                                                          \
+    F(kw_protected, "protected", keyword, ts)                                                      \
+    F(kw_public, "public", keyword, ts)                                                            \
+    F(kw_return, "return", keyword_control, js_ts)                                                 \
+    F(kw_set, "set", keyword, js_ts)                                                               \
+    F(kw_static, "static", keyword, js_ts)                                                         \
+    F(kw_super, "super", this_, js_ts)                                                             \
+    F(kw_switch, "switch", keyword_control, js_ts)                                                 \
+    F(kw_this, "this", this_, js_ts)                                                               \
+    F(kw_throw, "throw", keyword_control, js_ts)                                                   \
+    F(kw_true, "true", bool_, js_ts)                                                               \
+    F(kw_try, "try", keyword_control, js_ts)                                                       \
+    F(kw_type, "type", keyword, ts)                                                                \
+    F(kw_typeof, "typeof", keyword, js_ts)                                                         \
+    F(kw_var, "var", keyword, js_ts)                                                               \
+    F(kw_void, "void", keyword, js_ts)                                                             \
+    F(kw_while, "while", keyword_control, js_ts)                                                   \
+    F(kw_with, "with", keyword_control, js_ts)                                                     \
+    F(kw_yield, "yield", keyword, js_ts)                                                           \
+    F(left_brace, "{", sym_brace, all)                                                             \
+    F(bitwise_or, "|", sym_op, js_ts)                                                              \
+    F(bitwise_or_equal, "|=", sym_op, js_ts)                                                       \
+    F(logical_or, "||", sym_op, js_ts)                                                             \
+    F(logical_or_equal, "||=", sym_op, js_ts)                                                      \
+    F(right_brace, "}", sym_brace, all)                                                            \
+    F(bitwise_not, "~", sym_op, js_ts)
 
 #define ULIGHT_JS_TOKEN_ENUM_ENUMERATOR(id, code, highlight, source) id,
 
@@ -133,25 +153,6 @@ enum struct Token_Type : Underlying { //
 };
 
 inline constexpr auto js_token_type_count = std::size_t(Token_Type::bitwise_not) + 1;
-
-/// @brief Returns the in-code representation of `type`.
-/// For example, if `type` is `plus`, returns `"+"`.
-/// If `type` is invalid, returns an empty string.
-[[nodiscard]]
-std::u8string_view js_token_type_code(Token_Type type);
-
-/// @brief Equivalent to `js_token_type_code(type).length()`.
-[[nodiscard]]
-std::size_t js_token_type_length(Token_Type type);
-
-[[nodiscard]]
-Highlight_Type js_token_type_highlight(Token_Type type);
-
-[[nodiscard]]
-Feature_Source js_token_type_source(Token_Type type);
-
-[[nodiscard]]
-std::optional<Token_Type> js_token_type_by_code(std::u8string_view code);
 
 [[nodiscard]]
 bool starts_with_line_terminator(std::u8string_view s);
@@ -226,12 +227,6 @@ struct String_Literal_Result {
 /// @brief Matches a JavaScript string literal at the start of `str`.
 [[nodiscard]]
 String_Literal_Result match_string_literal(std::u8string_view str);
-
-#if 0
-/// @brief Matches a JavaScript template literal at the start of `str`.
-[[nodiscard]]
-String_Literal_Result match_template(std::u8string_view str);
-#endif
 
 /// @brief Matches a JavaScript template literal substitution at the start of `str`.
 /// Returns the position after the closing } if found.

--- a/include/ulight/ulight.h
+++ b/include/ulight/ulight.h
@@ -54,7 +54,7 @@ typedef struct ulight_u8string_view {
 enum {
     /// @brief The amount of unique languages supported,
     /// including `ULIGHT_LANG_NONE`.
-    ULIGHT_LANG_COUNT = 20
+    ULIGHT_LANG_COUNT = 21
 };
 
 /// @brief A language supported by ulight for syntax highlighting.
@@ -76,7 +76,7 @@ typedef enum ulight_lang {
     /// @brief HTML.
     ULIGHT_LANG_HTML = 4,
     /// @brief JavaScript.
-    ULIGHT_LANG_JS = 7,
+    ULIGHT_LANG_JAVASCRIPT = 7,
     /// @brief JSON (JavaScript Object Notation).
     ULIGHT_LANG_JSON = 10,
     /// @brief JSON with comments.
@@ -89,16 +89,18 @@ typedef enum ulight_lang {
     ULIGHT_LANG_LUA = 3,
     /// @brief Netwide Assembler.
     ULIGHT_LANG_NASM = 16,
+    /// @brief No langage (null result).
+    ULIGHT_LANG_NONE = 0,
     /// @brief Python.
     ULIGHT_LANG_PYTHON = 18,
     /// @brief TeX.
     ULIGHT_LANG_TEX = 14,
     /// @brief Plaintext.
     ULIGHT_LANG_TXT = 13,
+    /// @brief TeX.
+    ULIGHT_LANG_TYPESCRIPT = 20,
     /// @brief XML.
     ULIGHT_LANG_XML = 12,
-    /// @brief No langage (null result).
-    ULIGHT_LANG_NONE = 0,
 } ulight_lang;
 
 /// @brief Returns the `ulight_lang` whose name matches `name` exactly,

--- a/include/ulight/ulight.hpp
+++ b/include/ulight/ulight.hpp
@@ -25,7 +25,7 @@ enum struct Lang : Underlying {
     diff = ULIGHT_LANG_DIFF,
     ebnf = ULIGHT_LANG_EBNF,
     html = ULIGHT_LANG_HTML,
-    js = ULIGHT_LANG_JS,
+    javascript = ULIGHT_LANG_JAVASCRIPT,
     json = ULIGHT_LANG_JSON,
     jsonc = ULIGHT_LANG_JSONC,
     kotlin = ULIGHT_LANG_KOTLIN,
@@ -35,6 +35,7 @@ enum struct Lang : Underlying {
     python = ULIGHT_LANG_PYTHON,
     tex = ULIGHT_LANG_TEX,
     txt = ULIGHT_LANG_TXT,
+    typescript = ULIGHT_LANG_TYPESCRIPT,
     xml = ULIGHT_LANG_XML,
     none = ULIGHT_LANG_NONE,
 };

--- a/src/main/cpp/lang/html.cpp
+++ b/src/main/cpp/lang/html.cpp
@@ -406,7 +406,7 @@ private:
         }
         if (equals_ascii_ignore_case(name, script_tag)) {
             const std::size_t js_length = match_raw_text(remainder, script_tag);
-            consume_nested_css_or_js(Lang::js, js_length);
+            consume_nested_css_or_js(Lang::javascript, js_length);
             return true;
         }
         if (equals_ascii_ignore_case(name, style_tag)) {
@@ -420,7 +420,7 @@ private:
 
     void consume_nested_css_or_js(Lang lang, std::size_t length)
     {
-        ULIGHT_ASSERT(lang == Lang::css || lang == Lang::js);
+        ULIGHT_ASSERT(lang == Lang::css || lang == Lang::javascript);
         if (length == 0) {
             return;
         }

--- a/src/main/cpp/ulight.cpp
+++ b/src/main/cpp/ulight.cpp
@@ -104,11 +104,11 @@ constexpr ulight_lang_entry ulight_lang_list[] {
     make_lang_entry("htm", ULIGHT_LANG_HTML),
     make_lang_entry("html", ULIGHT_LANG_HTML),
     make_lang_entry("hxx", ULIGHT_LANG_CPP),
-    make_lang_entry("javascript", ULIGHT_LANG_JS),
-    make_lang_entry("js", ULIGHT_LANG_JS),
+    make_lang_entry("javascript", ULIGHT_LANG_JAVASCRIPT),
+    make_lang_entry("js", ULIGHT_LANG_JAVASCRIPT),
     make_lang_entry("json", ULIGHT_LANG_JSON),
     make_lang_entry("jsonc", ULIGHT_LANG_JSONC),
-    make_lang_entry("jsx", ULIGHT_LANG_JS),
+    make_lang_entry("jsx", ULIGHT_LANG_JAVASCRIPT),
     make_lang_entry("kotlin", ULIGHT_LANG_KOTLIN),
     make_lang_entry("kt", ULIGHT_LANG_KOTLIN),
     make_lang_entry("kts", ULIGHT_LANG_KOTLIN),
@@ -125,7 +125,10 @@ constexpr ulight_lang_entry ulight_lang_list[] {
     make_lang_entry("svg", ULIGHT_LANG_XML),
     make_lang_entry("tex", ULIGHT_LANG_TEX),
     make_lang_entry("text", ULIGHT_LANG_TXT),
+    make_lang_entry("ts", ULIGHT_LANG_TYPESCRIPT),
+    make_lang_entry("tsx", ULIGHT_LANG_TYPESCRIPT),
     make_lang_entry("txt", ULIGHT_LANG_TXT),
+    make_lang_entry("typescript", ULIGHT_LANG_TYPESCRIPT),
     make_lang_entry("x86asm", ULIGHT_LANG_NASM),
     make_lang_entry("xbj", ULIGHT_LANG_XML),
     make_lang_entry("xhtml", ULIGHT_LANG_XML),
@@ -160,6 +163,7 @@ constexpr ulight_string_view ulight_lang_display_names[ULIGHT_LANG_COUNT] {
     make_sv("EBNF"),
     make_sv("Python"),
     make_sv("Kotlin"),
+    make_sv("TypeScript"),
 };
 // clang-format on
 

--- a/test/highlight/typescript/class.ts
+++ b/test/highlight/typescript/class.ts
@@ -1,0 +1,12 @@
+class Base { }
+interface Interface { }
+class C extends Base implements Interface {
+    b: boolean
+    constructor(b: any) {
+        super()
+        this.b = b
+    }
+    private x?: any
+    protected y?: any
+    public z?: any
+}

--- a/test/highlight/typescript/class.ts.html
+++ b/test/highlight/typescript/class.ts.html
@@ -1,0 +1,12 @@
+<h- data-h=kw>class</h-> <h- data-h=id>Base</h-> <h- data-h=sym_brac>{</h-> <h- data-h=sym_brac>}</h->
+<h- data-h=kw>interface</h-> <h- data-h=id>Interface</h-> <h- data-h=sym_brac>{</h-> <h- data-h=sym_brac>}</h->
+<h- data-h=kw>class</h-> <h- data-h=id>C</h-> <h- data-h=kw>extends</h-> <h- data-h=id>Base</h-> <h- data-h=kw>implements</h-> <h- data-h=id>Interface</h-> <h- data-h=sym_brac>{</h->
+    <h- data-h=id>b</h-><h- data-h=sym_op>:</h-> <h- data-h=kw_type>boolean</h->
+    <h- data-h=kw>constructor</h-><h- data-h=sym_par>(</h-><h- data-h=id>b</h-><h- data-h=sym_op>:</h-> <h- data-h=kw_type>any</h-><h- data-h=sym_par>)</h-> <h- data-h=sym_brac>{</h->
+        <h- data-h=this>super</h-><h- data-h=sym_par>(</h-><h- data-h=sym_par>)</h->
+        <h- data-h=this>this</h-><h- data-h=sym_op>.</h-><h- data-h=id>b</h-> <h- data-h=sym_op>=</h-> <h- data-h=id>b</h->
+    <h- data-h=sym_brac>}</h->
+    <h- data-h=kw>private</h-> <h- data-h=id>x</h-><h- data-h=sym_op>?</h-><h- data-h=sym_op>:</h-> <h- data-h=kw_type>any</h->
+    <h- data-h=kw>protected</h-> <h- data-h=id>y</h-><h- data-h=sym_op>?</h-><h- data-h=sym_op>:</h-> <h- data-h=kw_type>any</h->
+    <h- data-h=kw>public</h-> <h- data-h=id>z</h-><h- data-h=sym_op>?</h-><h- data-h=sym_op>:</h-> <h- data-h=kw_type>any</h->
+<h- data-h=sym_brac>}</h->

--- a/test/highlight/typescript/type.ts
+++ b/test/highlight/typescript/type.ts
@@ -1,0 +1,2 @@
+type B = boolean;
+type S = { x: number }

--- a/test/highlight/typescript/type.ts.html
+++ b/test/highlight/typescript/type.ts.html
@@ -1,0 +1,2 @@
+<h- data-h=kw>type</h-> <h- data-h=id>B</h-> <h- data-h=sym_op>=</h-> <h- data-h=kw_type>boolean</h-><h- data-h=sym_punc>;</h->
+<h- data-h=kw>type</h-> <h- data-h=id>S</h-> <h- data-h=sym_op>=</h-> <h- data-h=sym_brac>{</h-> <h- data-h=id>x</h-><h- data-h=sym_op>:</h-> <h- data-h=id>number</h-> <h- data-h=sym_brac>}</h->


### PR DESCRIPTION
Closes #15.

This also includes a few refactors in the area of JS code. For the most part, TypeScript is a superset of JavaScript, so the existing highlighter can be repurposed. The only change actually needed is to disable certain keywords and tokens in JS mode.