### PR TITLE
Support for prolog of XML documents

### DIFF
--- a/include/ulight/impl/lang/xml.hpp
+++ b/include/ulight/impl/lang/xml.hpp
@@ -29,5 +29,60 @@ html::Match_Result match_comment(std::u8string_view str);
 [[nodiscard]]
 std::size_t match_text(std::u8string_view str);
 
+/// @brief Matches xml name at the beginning of `str`
+///        and returns the length of the name.
+///        If `str` does not start with a zero is returned.
+[[nodiscard]]
+std::size_t match_name(std::u8string_view str);
+
+/// @brief Matches an atttype at the beginning of `str` and returns
+///        its length.
+///        https://www.w3.org/TR/xml/#NT-AttType, however
+///        it does not match any names that belong to
+///        https://www.w3.org/TR/xml/#NT-EnumeratedType
+[[nodiscard]]
+std::size_t match_att_type(std::u8string_view str);
+
+/// @brief Matches one of default decl types at the
+///        ("#IMPLIED", "#FIXED", "#REQUIRED")
+///        at the start of `str`.
+///        https://www.w3.org/TR/xml/#NT-DefaultDecl
+[[nodiscard]]
+std::size_t match_default_decl_type(std::u8string_view str);
+
+/// @brief Matches one of the external id types ("SYSTEM", "PUBLIC") at
+///        the beginning of `str`.
+///        https://www.w3.org/TR/xml/#NT-ExternalID
+[[nodiscard]]
+std::size_t match_external_id_type(std::u8string_view str);
+
+/// @brief Matches the a content spec type ("EMPTY", "ANY")
+///        at the beginning of `str`.
+///        https://www.w3.org/TR/xml/#NT-contentspec
+[[nodiscard]]
+std::size_t match_content_spec_type(std::u8string_view str);
+
+/// @brief Checks if `str` starts with "NDATA", if so
+///        the length of the string "NDATA" is returned.
+///        https://www.w3.org/TR/xml/#NT-NDataDecl
+[[nodiscard]]
+std::size_t match_ndata_decl(std::u8string_view str);
+
+/// @brief Checks if `str` starts with "#PCDATA", if so
+///        the length of the string "#PCDATA" is returned.
+///        https://www.w3.org/TR/xml/#NT-Mixed
+[[nodiscard]]
+std::size_t match_pcdata_decl(std::u8string_view str);
+
+/// @brief matches an entity reference at the beginning of `str`.
+///        https://www.w3.org/TR/xml/#NT-EntityRef
+[[nodiscard]]
+std::size_t match_entity_reference(std::u8string_view str);
+
+/// @brief mathces a processed entity reference at the start of
+///        `str`. https://www.w3.org/TR/xml/#NT-PEReference.
+[[nodiscard]]
+std::size_t match_pe_reference(std::u8string_view str);
+
 } // namespace ulight::xml
 #endif

--- a/include/ulight/impl/lang/xml_chars.hpp
+++ b/include/ulight/impl/lang/xml_chars.hpp
@@ -3,6 +3,9 @@
 
 #include "ulight/impl/ascii_chars.hpp"
 
+#include <algorithm>
+#include <array>
+
 namespace ulight::xml {
 
 /// @brief Returns true iff `c` is whitespace according to the XML standard.
@@ -43,7 +46,8 @@ constexpr bool is_xml_name_start(char32_t c) noexcept
         || (c >= U'\u2c00' && c <= U'\u2fef') //
         || (c >= U'\u3001' && c <= U'\ud7ff') //
         || (c >= U'\uf900' && c <= U'\ufdcf') //
-        || (c >= U'\ufdf0' && c <= U'\ufffd');
+        || (c >= U'\ufdf0' && c <= U'\ufffd') //
+        || (c >= U'\U00010000' && c <= U'\U000effef');
 }
 
 constexpr bool is_xml_name(char8_t c) = delete;
@@ -61,6 +65,16 @@ constexpr bool is_xml_name(char32_t c) noexcept
         || c == U'\u00b7' //
         || (c >= U'\u0300' && c <= U'\u036f') //
         || (c >= U'\u203f' && c <= U'\u2040');
+}
+
+/// @brief Returns true of `c` is a non name char
+///        but is allowed to appear in contentspec
+constexpr bool is_contentspec_non_name_char(char8_t c) noexcept
+{
+    static constexpr std::array<char8_t, 7> non_name_chars
+        = { u8'(', u8')', u8'|', u8'*', u8'+', u8'?', ',' };
+
+    return std::ranges::find(non_name_chars, c) != std::end(non_name_chars);
 }
 
 } // namespace ulight::xml

--- a/src/main/cpp/lang/xml.cpp
+++ b/src/main/cpp/lang/xml.cpp
@@ -46,7 +46,7 @@ constexpr std::u8string_view decltype_standalone_attr = u8"standalone";
 } // namespace
 
 [[nodiscard]]
-std::size_t match_name(std::u8string_view str)
+std::size_t match_name(const std::u8string_view str)
 {
     if (str.empty()) {
         return 0;
@@ -66,13 +66,13 @@ std::size_t match_name(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_att_type(std::u8string_view str)
+std::size_t match_att_type(const std::u8string_view str)
 {
     // consider the next "word" (everything until whitespace or >)
     // to avoid "highlight splitting"
-    std::size_t word_len
+    const std::size_t word_len
         = ascii::find_if(str, [](char8_t c) { return is_xml_whitespace(c) || c == u8'>'; });
-    std::u8string_view word = str.substr(0, word_len);
+    const std::u8string_view word = str.substr(0, word_len);
 
     for (const auto& att_type_string : attlist_att_types) {
         if (word == att_type_string) {
@@ -84,7 +84,7 @@ std::size_t match_att_type(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_default_decl_type(std::u8string_view str)
+std::size_t match_default_decl_type(const std::u8string_view str)
 {
     for (const auto& default_decl_type : default_decl_types) {
         if (str.starts_with(default_decl_type)) {
@@ -96,7 +96,7 @@ std::size_t match_default_decl_type(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_external_id_type(std::u8string_view str)
+std::size_t match_external_id_type(const std::u8string_view str)
 {
     if (str.starts_with(external_id_public)) {
         return external_id_public.size();
@@ -110,7 +110,7 @@ std::size_t match_external_id_type(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_content_spec_type(std::u8string_view str)
+std::size_t match_content_spec_type(const std::u8string_view str)
 {
     if (str.starts_with(content_spec_empty)) {
         return content_spec_empty.size();
@@ -124,30 +124,27 @@ std::size_t match_content_spec_type(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_ndata_decl(std::u8string_view str)
+std::size_t match_ndata_decl(const std::u8string_view str)
 {
     return str.starts_with(ndata_decl_string) ? ndata_decl_string.size() : 0;
 }
 
 [[nodiscard]]
-std::size_t match_pcdata_decl(std::u8string_view str)
+std::size_t match_pcdata_decl(const std::u8string_view str)
 {
     return str.starts_with(pcdata_decl_string) ? pcdata_decl_string.size() : 0;
 }
 
 [[nodiscard]]
-std::size_t match_whitespace(std::u8string_view str)
+std::size_t match_whitespace(const std::u8string_view str)
 {
     return ascii::length_if(str, [](char8_t c) { return is_xml_whitespace(c); });
 }
 
 [[nodiscard]]
-std::size_t match_text(std::u8string_view str)
+std::size_t match_text(const std::u8string_view str)
 {
-    const std::size_t result
-        = ascii::length_if_not(str, [](char8_t c) { return c == u8'<' || c == u8'&'; });
-
-    return result == std::u8string_view::npos ? str.length() : result;
+    return ascii::length_if_not(str, [](char8_t c) { return c == u8'<' || c == u8'&'; });
 }
 
 [[nodiscard]]
@@ -177,7 +174,7 @@ html::Match_Result match_comment(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_entity_reference(std::u8string_view str)
+std::size_t match_entity_reference(const std::u8string_view str)
 {
     if (!str.starts_with(u8'%')) {
         return 0;
@@ -190,7 +187,7 @@ std::size_t match_entity_reference(std::u8string_view str)
 }
 
 [[nodiscard]]
-std::size_t match_pe_reference(std::u8string_view str)
+std::size_t match_pe_reference(const std::u8string_view str)
 {
 
     if (!str.starts_with(u8'&')) {
@@ -198,7 +195,7 @@ std::size_t match_pe_reference(std::u8string_view str)
     }
 
     const std::size_t result = str.find(u8';', 1);
-    std::u8string_view ref_content = str.substr(1, result - 1);
+    const std::u8string_view ref_content = str.substr(1, result - 1);
     const bool success
         = result != std::u8string_view::npos && match_name(ref_content) == ref_content.size();
     return success ? result + 1 : 0;
@@ -206,9 +203,10 @@ std::size_t match_pe_reference(std::u8string_view str)
 
 struct XML_Highlighter : Highlighter_Base {
 
+    [[nodiscard]]
     XML_Highlighter(
         Non_Owning_Buffer<Token>& out,
-        std::u8string_view source,
+        const std::u8string_view source,
         const Highlight_Options& options
     )
         : Highlighter_Base(out, source, options)
@@ -234,9 +232,9 @@ struct XML_Highlighter : Highlighter_Base {
     }
 
 private:
-    // https://www.w3.org/TR/xml/#NT-ExternalID
     bool expect_external_id()
     {
+        // https://www.w3.org/TR/xml/#NT-ExternalID
         const std::size_t external_id_len
             = utf8::find_if(remainder, [](char32_t c) { return is_xml_whitespace(c); });
         const std::u8string_view external_id = remainder.substr(0, external_id_len);
@@ -260,8 +258,7 @@ private:
         return false;
     }
 
-    // This method matches a superset of
-    // https://www.w3.org/TR/xml/#NT-markupdecl
+    // Matches a superset of https://www.w3.org/TR/xml/#NT-markupdecl
     // to provide better highlighting.
     bool expect_markup_decl()
     {
@@ -337,9 +334,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-doctypedecl
     bool expect_doctype_decl()
     {
+        // https://www.w3.org/TR/xml/#NT-doctypedecl
         if (!remainder.starts_with(u8"<!")) {
             return false;
         }
@@ -402,9 +399,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-XMLDecl
     bool expect_xml_decl()
     {
+        // https://www.w3.org/TR/xml/#NT-XMLDecl
         if (!remainder.starts_with(xml_tag)) {
             return false;
         }
@@ -462,9 +459,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-prolog
     bool expect_prolog()
     {
+        // https://www.w3.org/TR/xml/#NT-prolog
         expect_xml_decl();
 
         while (expect_processing_instruction() || expect_comment() || expect_whitespace()) { }
@@ -473,9 +470,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-PI
     bool expect_processing_instruction()
     {
+        // https://www.w3.org/TR/xml/#NT-PI
         if (!remainder.starts_with(u8"<?")) {
             return false;
         }
@@ -510,9 +507,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#dt-cdsection
     bool expect_cdata_section()
     {
+        // https://www.w3.org/TR/xml/#dt-cdsection
         if (const auto cdata_section = html::match_cdata(remainder)) {
             std::size_t pure_cdata_len = cdata_section.length - cdata_section_prefix.length();
 
@@ -534,9 +531,9 @@ private:
         return false;
     }
 
-    // https://www.w3.org/TR/xml/#NT-CharRef
     bool expect_reference()
     {
+        // https://www.w3.org/TR/xml/#NT-CharRef
         if (std::size_t ref_length = html::match_character_reference(remainder)) {
             emit_and_advance(ref_length, Highlight_Type::string_escape);
             return true;
@@ -544,10 +541,10 @@ private:
         return false;
     }
 
-    // https://www.w3.org/TR/xml/#NT-STag as well
-    // as https://www.w3.org/TR/xml/#NT-EmptyElemTag
     bool expect_start_tag()
     {
+        // https://www.w3.org/TR/xml/#NT-STag as well as
+        // https://www.w3.org/TR/xml/#NT-EmptyElemTag
         if (!remainder.starts_with(u8'<')) {
             return false;
         }
@@ -586,9 +583,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-Attribute
     bool expect_attribute()
     {
+        // https://www.w3.org/TR/xml/#NT-Attribute
         constexpr auto is_attribute_name_end = [](std::u8string_view str) {
             return match_whitespace(str) //
                 || str.starts_with(u8"/>") //
@@ -610,9 +607,9 @@ private:
         return expect_attribute_value();
     }
 
-    // https://www.w3.org/TR/xml/#NT-AttValue
     bool expect_attribute_value()
     {
+        // https://www.w3.org/TR/xml/#NT-AttValue
         char8_t quote_type;
         if (remainder.starts_with(u8'\'')) {
             quote_type = u8'\'';
@@ -663,9 +660,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-Comment
     bool expect_comment()
     {
+        // https://www.w3.org/TR/xml/#NT-Comment
         const html::Match_Result comment = match_comment(remainder);
         if (!comment) {
             return false;
@@ -690,9 +687,9 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-ETag
     bool expect_end_tag()
     {
+        // https://www.w3.org/TR/xml/#NT-ETag
         if (!remainder.starts_with(u8"</")) {
             return false;
         }
@@ -737,11 +734,11 @@ private:
         return true;
     }
 
-    // https://www.w3.org/TR/xml/#NT-Name
     template <typename Stop>
         requires std::is_invocable_r_v<bool, Stop, std::u8string_view>
     std::size_t expect_name(Highlight_Type type, Stop is_stop)
     {
+        // https://www.w3.org/TR/xml/#NT-Name
         std::size_t total_length = 0;
         std::size_t piece_length = 0;
 

--- a/src/main/cpp/lang/xml.cpp
+++ b/src/main/cpp/lang/xml.cpp
@@ -1,16 +1,19 @@
-#include "ulight/impl/lang/xml.hpp"
-#include "ulight/impl/lang/html.hpp"
-#include "ulight/impl/lang/xml_chars.hpp"
+#include <cstddef>
+#include <string_view>
+
+#include "ulight/ulight.hpp"
 
 #include "ulight/impl/ascii_algorithm.hpp"
 #include "ulight/impl/buffer.hpp"
 #include "ulight/impl/highlight.hpp"
 #include "ulight/impl/highlighter.hpp"
+#include "ulight/impl/numbers.hpp"
 #include "ulight/impl/unicode.hpp"
+#include "ulight/impl/unicode_algorithm.hpp"
 
-#include "ulight/ulight.hpp"
-
-#include <cctype>
+#include "ulight/impl/lang/html.hpp"
+#include "ulight/impl/lang/xml.hpp"
+#include "ulight/impl/lang/xml_chars.hpp"
 
 namespace ulight {
 
@@ -18,13 +21,119 @@ namespace xml {
 
 namespace {
 
+constexpr std::u8string_view attlist_att_types[]
+    = { u8"CDATA",    u8"IDREFS",   u8"IDREF",   u8"ID",      u8"ENTITY",
+        u8"ENTITIES", u8"NMTOKENS", u8"NMTOKEN", u8"NOTATION" };
+constexpr std::u8string_view default_decl_types[] = { u8"#REQUIRED", u8"#IMPLIED", u8"#FIXED" };
+
 constexpr std::u8string_view comment_prefix = u8"<!--";
 constexpr std::u8string_view comment_suffix = u8"-->";
 constexpr std::u8string_view illegal_comment_sequence = u8"--";
 constexpr std::u8string_view cdata_section_prefix = u8"<![CDATA[";
 constexpr std::u8string_view cdata_section_suffix = u8"]]>";
+constexpr std::u8string_view xml_tag = u8"<?xml";
+constexpr std::u8string_view external_id_public = u8"PUBLIC";
+constexpr std::u8string_view external_id_system = u8"SYSTEM";
+constexpr std::u8string_view content_spec_empty = u8"EMPTY";
+constexpr std::u8string_view content_spec_any = u8"ANY";
+constexpr std::u8string_view ndata_decl_string = u8"NDATA";
+constexpr std::u8string_view pcdata_decl_string = u8"#PCDATA";
+
+constexpr std::u8string_view decltype_version_attr = u8"version";
+constexpr std::u8string_view decltype_encoding_attr = u8"encoding";
+constexpr std::u8string_view decltype_standalone_attr = u8"standalone";
 
 } // namespace
+
+[[nodiscard]]
+std::size_t match_name(std::u8string_view str)
+{
+    if (str.empty()) {
+        return 0;
+    }
+
+    std::size_t name_len = 0;
+    while (name_len < str.size()) {
+        auto [code_point, length] = utf8::decode_and_length_or_replacement(str.substr(name_len));
+
+        if (!is_xml_name(code_point)) {
+            return name_len;
+        }
+        name_len++;
+    }
+
+    return name_len;
+}
+
+[[nodiscard]]
+std::size_t match_att_type(std::u8string_view str)
+{
+    // consider the next "word" (everything until whitespace or >)
+    // to avoid "highlight splitting"
+    std::size_t word_len
+        = ascii::find_if(str, [](char8_t c) { return is_xml_whitespace(c) || c == u8'>'; });
+    std::u8string_view word = str.substr(0, word_len);
+
+    for (const auto& att_type_string : attlist_att_types) {
+        if (word == att_type_string) {
+            return att_type_string.length();
+        }
+    }
+
+    return 0;
+}
+
+[[nodiscard]]
+std::size_t match_default_decl_type(std::u8string_view str)
+{
+    for (const auto& default_decl_type : default_decl_types) {
+        if (str.starts_with(default_decl_type)) {
+            return default_decl_type.size();
+        }
+    }
+
+    return 0;
+}
+
+[[nodiscard]]
+std::size_t match_external_id_type(std::u8string_view str)
+{
+    if (str.starts_with(external_id_public)) {
+        return external_id_public.size();
+    }
+
+    if (str.starts_with(external_id_system)) {
+        return external_id_system.size();
+    }
+
+    return 0;
+}
+
+[[nodiscard]]
+std::size_t match_content_spec_type(std::u8string_view str)
+{
+    if (str.starts_with(content_spec_empty)) {
+        return content_spec_empty.size();
+    }
+
+    if (str.starts_with(content_spec_any)) {
+        return content_spec_any.size();
+    }
+
+    return 0;
+}
+
+[[nodiscard]]
+std::size_t match_ndata_decl(std::u8string_view str)
+{
+    return str.starts_with(ndata_decl_string) ? ndata_decl_string.size() : 0;
+}
+
+[[nodiscard]]
+std::size_t match_pcdata_decl(std::u8string_view str)
+{
+    return str.starts_with(pcdata_decl_string) ? pcdata_decl_string.size() : 0;
+}
 
 [[nodiscard]]
 std::size_t match_whitespace(std::u8string_view str)
@@ -67,6 +176,34 @@ html::Match_Result match_comment(std::u8string_view str)
     return { length, false };
 }
 
+[[nodiscard]]
+std::size_t match_entity_reference(std::u8string_view str)
+{
+    if (!str.starts_with(u8'%')) {
+        return 0;
+    }
+    const std::size_t result = str.find(u8';', 1);
+    std::u8string_view ref_content = str.substr(1, result - 1);
+    const bool success
+        = result != std::u8string_view::npos && match_name(ref_content) == ref_content.size();
+    return success ? result + 1 : 0;
+}
+
+[[nodiscard]]
+std::size_t match_pe_reference(std::u8string_view str)
+{
+
+    if (!str.starts_with(u8'&')) {
+        return 0;
+    }
+
+    const std::size_t result = str.find(u8';', 1);
+    std::u8string_view ref_content = str.substr(1, result - 1);
+    const bool success
+        = result != std::u8string_view::npos && match_name(ref_content) == ref_content.size();
+    return success ? result + 1 : 0;
+}
+
 struct XML_Highlighter : Highlighter_Base {
 
     XML_Highlighter(
@@ -78,9 +215,9 @@ struct XML_Highlighter : Highlighter_Base {
     {
     }
 
-    // TODO: add prolog (declaration)
     bool operator()()
     {
+        expect_prolog();
         while (!remainder.empty()) {
             if (expect_comment() || //
                 expect_cdata_section() || //
@@ -97,6 +234,246 @@ struct XML_Highlighter : Highlighter_Base {
     }
 
 private:
+    // https://www.w3.org/TR/xml/#NT-ExternalID
+    bool expect_external_id()
+    {
+        const std::size_t external_id_len
+            = utf8::find_if(remainder, [](char32_t c) { return is_xml_whitespace(c); });
+        const std::u8string_view external_id = remainder.substr(0, external_id_len);
+
+        if (external_id == external_id_system) {
+            emit_and_advance(external_id_system.size(), Highlight_Type::keyword);
+            expect_whitespace();
+            expect_attribute_value();
+            return true;
+        }
+
+        if (external_id == external_id_public) {
+            emit_and_advance(external_id_public.size(), Highlight_Type::keyword);
+            expect_whitespace();
+            expect_attribute_value();
+            expect_whitespace();
+            expect_attribute_value();
+            return true;
+        }
+
+        return false;
+    }
+
+    // This method matches a superset of
+    // https://www.w3.org/TR/xml/#NT-markupdecl
+    // to provide better highlighting.
+    bool expect_markup_decl()
+    {
+        if (expect_comment() || expect_processing_instruction()) {
+            return true;
+        }
+
+        if (!remainder.starts_with(u8"<!")) {
+            return false;
+        }
+
+        emit_and_advance(2, Highlight_Type::name_macro);
+        constexpr auto after_markup_decl_name
+            = [](std::u8string_view str) { return match_whitespace(str); };
+
+        expect_name(Highlight_Type::name_macro, after_markup_decl_name);
+        expect_whitespace();
+
+        // for entity declarations there could be an extra '%'
+        if (remainder.starts_with(u8'%')) {
+            emit_and_advance(1, Highlight_Type::symbol_punc);
+            expect_whitespace();
+        }
+
+        expect_name(Highlight_Type::name, after_markup_decl_name);
+        expect_whitespace();
+
+        while (!remainder.starts_with(u8'>') && !remainder.empty()) {
+
+            if (remainder.starts_with(u8')') || //
+                remainder.starts_with(u8'(') || //
+                remainder.starts_with(u8'|') || //
+                remainder.starts_with(u8'*') || //
+                remainder.starts_with(u8',')) { //
+                emit_and_advance(1, Highlight_Type::symbol_punc);
+            }
+            else if (const std::size_t att_type_len = match_att_type(remainder)) {
+                emit_and_advance(att_type_len, Highlight_Type::keyword);
+            }
+            else if (const std::size_t default_decl_len = match_default_decl_type(remainder)) {
+                emit_and_advance(default_decl_len, Highlight_Type::keyword);
+            }
+            else if (const std::size_t external_id_len = match_external_id_type(remainder)) {
+                emit_and_advance(external_id_len, Highlight_Type::keyword);
+            }
+            else if (const std::size_t content_spec_len = match_content_spec_type(remainder)) {
+                emit_and_advance(content_spec_len, Highlight_Type::keyword);
+            }
+            else if (const std::size_t ndata_len = match_ndata_decl(remainder)) {
+                emit_and_advance(ndata_len, Highlight_Type::keyword);
+            }
+            else if (const std::size_t pcdata_decl_len = match_pcdata_decl(remainder)) {
+                emit_and_advance(pcdata_decl_len, Highlight_Type::keyword);
+            }
+            else if (const std::size_t pe_ref_len = match_pe_reference(remainder)) {
+                emit_and_advance(pe_ref_len, Highlight_Type::string_escape);
+            }
+            else if (const std::size_t name_len = match_name(remainder)) {
+                emit_and_advance(name_len, Highlight_Type::name);
+            }
+            else if (remainder.starts_with(u8'\'') || remainder.starts_with(u8'"')) {
+                expect_attribute_value();
+            }
+            else {
+                const std::size_t len = ascii::length_if_not(remainder, [](char8_t c) {
+                    return is_xml_whitespace(c) || c == u8'>';
+                });
+                advance(len);
+            }
+            expect_whitespace();
+        }
+
+        return true;
+    }
+
+    // https://www.w3.org/TR/xml/#NT-doctypedecl
+    bool expect_doctype_decl()
+    {
+        if (!remainder.starts_with(u8"<!")) {
+            return false;
+        }
+        emit_and_advance(2, Highlight_Type::name_macro);
+
+        constexpr auto stop = [](std::u8string_view str) {
+            return str.starts_with(u8'[') || str.starts_with(u8'>') || match_whitespace(str);
+        };
+
+        expect_name(Highlight_Type::name_macro, stop);
+        expect_whitespace();
+        expect_name(Highlight_Type::name, stop);
+
+        expect_whitespace();
+        if (match_external_id_type(remainder)) {
+            expect_external_id();
+        }
+        else if (!remainder.starts_with(u8'[')) {
+            const std::size_t word_len
+                = ascii::length_if_not(remainder, [](char8_t c) { return is_xml_whitespace(c); });
+            advance(word_len);
+
+            expect_whitespace();
+            if (remainder.starts_with(u8'\'') || remainder.starts_with(u8'"')) {
+                expect_attribute_value();
+            }
+            expect_whitespace();
+
+            if (remainder.starts_with(u8'\'') || remainder.starts_with(u8'"')) {
+                expect_attribute_value();
+            }
+        }
+
+        expect_whitespace();
+        if (!remainder.starts_with(u8'[')) {
+            return true;
+        }
+        emit_and_advance(1, Highlight_Type::symbol_punc);
+
+        expect_whitespace();
+        while (expect_markup_decl()) {
+            expect_whitespace();
+            if (remainder.starts_with(u8'>')) {
+                emit_and_advance(1, Highlight_Type::name_macro);
+            }
+            expect_whitespace();
+        }
+
+        if (!remainder.starts_with(u8']')) {
+            return true;
+        }
+        emit_and_advance(1, Highlight_Type::symbol_punc);
+        expect_whitespace();
+
+        if (!remainder.starts_with(u8'>')) {
+            return true;
+        }
+        emit_and_advance(1, Highlight_Type::name_macro);
+
+        return true;
+    }
+
+    // https://www.w3.org/TR/xml/#NT-XMLDecl
+    bool expect_xml_decl()
+    {
+        if (!remainder.starts_with(xml_tag)) {
+            return false;
+        }
+        emit_and_advance(xml_tag.size(), Highlight_Type::name_macro);
+        expect_whitespace();
+
+        const auto highlight_number = [&]() {
+            Common_Number_Result num_result
+                = match_common_number(remainder, Common_Number_Options {});
+            if (num_result.integer) {
+                emit_and_advance(num_result.integer, Highlight_Type::number);
+            }
+
+            if (num_result.radix_point) {
+                emit_and_advance(num_result.radix_point, Highlight_Type::symbol_punc);
+            }
+
+            if (num_result.fractional) {
+                emit_and_advance(num_result.fractional, Highlight_Type::number);
+            }
+        };
+
+        const auto expect_string = [&]() { expect_attribute_value(); };
+
+        const auto highlight_decl_attr = [&](std::u8string_view attr_name, auto expect_val) {
+            if (!remainder.starts_with(attr_name)) {
+                return;
+            }
+            emit_and_advance(attr_name.size(), Highlight_Type::markup_attr);
+
+            if (!remainder.starts_with(u8'=')) {
+                return;
+            }
+            emit_and_advance(1, Highlight_Type::symbol_punc);
+
+            if (!remainder.empty()) {
+                expect_val();
+            }
+        };
+
+        highlight_decl_attr(decltype_version_attr, highlight_number);
+        expect_whitespace();
+
+        highlight_decl_attr(decltype_encoding_attr, expect_string);
+        expect_whitespace();
+
+        highlight_decl_attr(decltype_standalone_attr, expect_string);
+        expect_whitespace();
+
+        if (!remainder.starts_with(u8"?>")) {
+            return true;
+        }
+
+        emit_and_advance(2, Highlight_Type::name_macro);
+        return true;
+    }
+
+    // https://www.w3.org/TR/xml/#NT-prolog
+    bool expect_prolog()
+    {
+        expect_xml_decl();
+
+        while (expect_processing_instruction() || expect_comment() || expect_whitespace()) { }
+
+        expect_doctype_decl();
+        return true;
+    }
+
+    // https://www.w3.org/TR/xml/#NT-PI
     bool expect_processing_instruction()
     {
         if (!remainder.starts_with(u8"<?")) {
@@ -113,14 +490,12 @@ private:
             return true;
         }
 
-        // TODO: this check for whether xml is in the name is most likely unnecessary and only
-        //       breaks highlighting
         const std::u8string_view target_name = remainder.substr(0, name_length);
         if (ascii::contains_ignore_case(target_name, u8"xml")) {
             return true;
         }
 
-        advance(match_whitespace(remainder));
+        expect_whitespace();
 
         while (!remainder.empty() && !remainder.starts_with(u8"?>")) {
             advance(1);
@@ -135,6 +510,7 @@ private:
         return true;
     }
 
+    // https://www.w3.org/TR/xml/#dt-cdsection
     bool expect_cdata_section()
     {
         if (const auto cdata_section = html::match_cdata(remainder)) {
@@ -158,6 +534,7 @@ private:
         return false;
     }
 
+    // https://www.w3.org/TR/xml/#NT-CharRef
     bool expect_reference()
     {
         if (std::size_t ref_length = html::match_character_reference(remainder)) {
@@ -167,6 +544,8 @@ private:
         return false;
     }
 
+    // https://www.w3.org/TR/xml/#NT-STag as well
+    // as https://www.w3.org/TR/xml/#NT-EmptyElemTag
     bool expect_start_tag()
     {
         if (!remainder.starts_with(u8'<')) {
@@ -186,7 +565,7 @@ private:
 
         while (!remainder.empty()) {
 
-            advance(match_whitespace(remainder));
+            expect_whitespace();
 
             if (remainder.starts_with(u8'>') || remainder.starts_with(u8"/>")) {
                 break;
@@ -207,6 +586,7 @@ private:
         return true;
     }
 
+    // https://www.w3.org/TR/xml/#NT-Attribute
     bool expect_attribute()
     {
         constexpr auto is_attribute_name_end = [](std::u8string_view str) {
@@ -217,7 +597,7 @@ private:
         };
         expect_name(Highlight_Type::markup_attr, is_attribute_name_end);
 
-        advance(match_whitespace(remainder));
+        expect_whitespace();
 
         if (!remainder.starts_with(u8'=')) {
             return true;
@@ -225,11 +605,12 @@ private:
 
         emit_and_advance(1, Highlight_Type::symbol_punc);
 
-        advance(match_whitespace(remainder));
+        expect_whitespace();
 
         return expect_attribute_value();
     }
 
+    // https://www.w3.org/TR/xml/#NT-AttValue
     bool expect_attribute_value()
     {
         char8_t quote_type;
@@ -255,14 +636,15 @@ private:
 
         while (!remainder.empty() && piece_length < remainder.length()
                && remainder[piece_length] != quote_type) {
-            if ((remainder[piece_length] == u8'&' && !html::match_character_reference(remainder))
+            std::u8string_view candidate = remainder.substr(piece_length);
+            if ((remainder[piece_length] == u8'&' && !html::match_character_reference(candidate))
                 || remainder[piece_length] == u8'<') {
                 highlight_piece();
                 emit_and_advance(1, Highlight_Type::error);
                 piece_length = 0;
             }
             else if (remainder[piece_length] == u8'&'
-                     && html::match_character_reference(remainder)) {
+                     && html::match_character_reference(candidate)) {
                 highlight_piece();
                 expect_reference();
                 piece_length = 0;
@@ -281,6 +663,7 @@ private:
         return true;
     }
 
+    // https://www.w3.org/TR/xml/#NT-Comment
     bool expect_comment()
     {
         const html::Match_Result comment = match_comment(remainder);
@@ -294,15 +677,12 @@ private:
             pure_comment_length -= comment_suffix.length();
         }
 
-        // match <--
         emit_and_advance(comment_prefix.length(), Highlight_Type::comment_delim);
 
-        // match actual comment
         if (pure_comment_length > 0) {
             emit_and_advance(pure_comment_length, Highlight_Type::comment);
         }
 
-        // match -->
         if (comment.terminated) {
             emit_and_advance(comment_suffix.length(), Highlight_Type::comment_delim);
         }
@@ -310,6 +690,7 @@ private:
         return true;
     }
 
+    // https://www.w3.org/TR/xml/#NT-ETag
     bool expect_end_tag()
     {
         if (!remainder.starts_with(u8"</")) {
@@ -327,7 +708,7 @@ private:
             return true;
         }
 
-        advance(match_whitespace(remainder));
+        expect_whitespace();
 
         if (remainder.starts_with(u8'>')) {
             emit_and_advance(1, Highlight_Type::symbol_punc);
@@ -356,6 +737,7 @@ private:
         return true;
     }
 
+    // https://www.w3.org/TR/xml/#NT-Name
     template <typename Stop>
         requires std::is_invocable_r_v<bool, Stop, std::u8string_view>
     std::size_t expect_name(Highlight_Type type, Stop is_stop)
@@ -386,6 +768,13 @@ private:
         }
 
         return total_length;
+    }
+
+    bool expect_whitespace()
+    {
+        std::size_t whitespace_len = match_whitespace(remainder);
+        advance(whitespace_len);
+        return whitespace_len != 0;
     }
 };
 

--- a/src/test/cpp/test_xml.cpp
+++ b/src/test/cpp/test_xml.cpp
@@ -17,19 +17,12 @@ TEST(XML, match_whitespace)
     EXPECT_EQ(match_whitespace(u8"\t\r\n"), 3);
 }
 
-TEST(XML, match_name_permissive)
+TEST(XML, match_entity_reference)
 {
-
-    Name_Match_Result result;
-    result = match_name_permissive(u8"simple_name", [](std::u8string_view) { return false; });
-    EXPECT_EQ(result.length, 11);
-    EXPECT_EQ(result.error_indicies.size(), 0);
-
-    result = match_name_permissive(u8"n&a&m&e", [](std::u8string_view) { return false; });
-    EXPECT_EQ(result.length, 7);
-    EXPECT_TRUE(result.error_indicies.contains(1));
-    EXPECT_TRUE(result.error_indicies.contains(3));
-    EXPECT_TRUE(result.error_indicies.contains(5));
+    EXPECT_EQ(match_entity_reference(u8"this is not a reference"), 0);
+    EXPECT_EQ(match_entity_reference(u8"%reference;"), 11);
+    EXPECT_EQ(match_entity_reference(u8"%reference; trailing"), 11);
+    EXPECT_EQ(match_entity_reference(u8"%re-f; illegal char"), 0);
 }
 
 } // namespace ulight::xml

--- a/test/highlight/xml/prolog.xml
+++ b/test/highlight/xml/prolog.xml
@@ -1,0 +1,28 @@
+<?xml version=1.99 encoding='UTF-8' standalone="yes"?>
+<!-- comment -->
+<!DOCTYP my_xml_document PUBLIC "extern" "extern" [
+    <!ELEMENT my_elem EMPTY >
+    <!ELEMENT my_elem ANY >
+    <!ELEMENT my_elem (#PCDATA|a|b|i)*>
+    <!ELEMENT my_elem (#PCDATA| (front, middle | rear))*   >
+    <!-- note we do not check if  every opening
+         paren has a closing paren -->
+    <?target hello ?>
+    <! my_elem (no_pc, data, (just | names)* >
+    <!ATTLIST my_attlist
+         attribute1 CDATA #REQUIRED
+         attribute2 ID #IMPLIED
+         attribute3 IDRF #FIXED "fixed"
+         attribute4 IDREFS #FIXD "front &ref;"
+         attribute5 ENTITY #IMPLIED
+         attribute6 ENTITIES #REQIRED
+         attribute7 NMTOKEN #FIXED '&ref; &ref; back'
+         attribute8 NMTOKENS #IPLIED 
+         attribute9 NOTTION ( name | name ) >
+    <!NOTATION my_notation PUBLIC "" >
+    <!ENTITY my_entity "entity" >
+    <!ENTITY my_entity "&ref; abc" >
+    <!ENTITY my_entity "abc %ref; abc" >
+    <!ENTITY my_entity PULIC "incorrect type" "extern" NDATA data>
+    <!ENTITY % my_entity PUBLIC>
+]>

--- a/test/highlight/xml/prolog.xml.html
+++ b/test/highlight/xml/prolog.xml.html
@@ -1,0 +1,28 @@
+<h- data-h=name_mac>&lt;?xml</h-> <h- data-h=mk_attr>version</h-><h- data-h=sym_punc>=</h-><h- data-h=num>1</h-><h- data-h=sym_punc>.</h-><h- data-h=num>99</h-> <h- data-h=mk_attr>encoding</h-><h- data-h=sym_punc>=</h-><h- data-h=str_dlim>'</h-><h- data-h=str>UTF-8</h-><h- data-h=str_dlim>'</h-> <h- data-h=mk_attr>standalone</h-><h- data-h=sym_punc>=</h-><h- data-h=str_dlim>"</h-><h- data-h=str>yes</h-><h- data-h=str_dlim>"</h-><h- data-h=name_mac>?&gt;</h->
+<h- data-h=cmt_dlim>&lt;!--</h-><h- data-h=cmt> comment </h-><h- data-h=cmt_dlim>--&gt;</h->
+<h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>DOCTYP</h-> <h- data-h=name>my_xml_document</h-> <h- data-h=kw>PUBLIC</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>extern</h-><h- data-h=str_dlim>"</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>extern</h-><h- data-h=str_dlim>"</h-> <h- data-h=sym_punc>[</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ELEMENT</h-> <h- data-h=name>my_elem</h-> <h- data-h=kw>EMPTY</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ELEMENT</h-> <h- data-h=name>my_elem</h-> <h- data-h=kw>ANY</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ELEMENT</h-> <h- data-h=name>my_elem</h-> <h- data-h=sym_punc>(</h-><h- data-h=kw>#PCDATA</h-><h- data-h=sym_punc>|</h-><h- data-h=name>a</h-><h- data-h=sym_punc>|</h-><h- data-h=name>b</h-><h- data-h=sym_punc>|</h-><h- data-h=name>i</h-><h- data-h=sym_punc>)</h-><h- data-h=sym_punc>*</h-><h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ELEMENT</h-> <h- data-h=name>my_elem</h-> <h- data-h=sym_punc>(</h-><h- data-h=kw>#PCDATA</h-><h- data-h=sym_punc>|</h-> <h- data-h=sym_punc>(</h-><h- data-h=name>front</h-><h- data-h=sym_punc>,</h-> <h- data-h=name>middle</h-> <h- data-h=sym_punc>|</h-> <h- data-h=name>rear</h-><h- data-h=sym_punc>)</h-><h- data-h=sym_punc>)</h-><h- data-h=sym_punc>*</h->   <h- data-h=name_mac>&gt;</h->
+    <h- data-h=cmt_dlim>&lt;!--</h-><h- data-h=cmt> note we do not check if  every opening
+         paren has a closing paren </h-><h- data-h=cmt_dlim>--&gt;</h->
+    <h- data-h=sym_punc>&lt;?</h-><h- data-h=name_mac>target</h-> hello <h- data-h=sym_punc>?&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-> <h- data-h=name>my_elem</h-> <h- data-h=sym_punc>(</h-><h- data-h=name>no_pc</h-><h- data-h=sym_punc>,</h-> <h- data-h=name>data</h-><h- data-h=sym_punc>,</h-> <h- data-h=sym_punc>(</h-><h- data-h=name>just</h-> <h- data-h=sym_punc>|</h-> <h- data-h=name>names</h-><h- data-h=sym_punc>)</h-><h- data-h=sym_punc>*</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ATTLIST</h-> <h- data-h=name>my_attlist</h->
+         <h- data-h=name>attribute1</h-> <h- data-h=kw>CDATA</h-> <h- data-h=kw>#REQUIRED</h->
+         <h- data-h=name>attribute2</h-> <h- data-h=kw>ID</h-> <h- data-h=kw>#IMPLIED</h->
+         <h- data-h=name>attribute3</h-> <h- data-h=name>IDRF</h-> <h- data-h=kw>#FIXED</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>fixed</h-><h- data-h=str_dlim>"</h->
+         <h- data-h=name>attribute4</h-> <h- data-h=kw>IDREFS</h-> #FIXD <h- data-h=str_dlim>"</h-><h- data-h=str>front </h-><h- data-h=str_esc>&amp;ref;</h-><h- data-h=str_dlim>"</h->
+         <h- data-h=name>attribute5</h-> <h- data-h=kw>ENTITY</h-> <h- data-h=kw>#IMPLIED</h->
+         <h- data-h=name>attribute6</h-> <h- data-h=kw>ENTITIES</h-> #REQIRED
+         <h- data-h=name>attribute7</h-> <h- data-h=kw>NMTOKEN</h-> <h- data-h=kw>#FIXED</h-> <h- data-h=str_dlim>'</h-><h- data-h=str_esc>&amp;ref;</h-><h- data-h=str> </h-><h- data-h=str_esc>&amp;ref;</h-><h- data-h=str> back</h-><h- data-h=str_dlim>'</h->
+         <h- data-h=name>attribute8</h-> <h- data-h=kw>NMTOKENS</h-> #IPLIED 
+         <h- data-h=name>attribute9</h-> <h- data-h=name>NOTTION</h-> <h- data-h=sym_punc>(</h-> <h- data-h=name>name</h-> <h- data-h=sym_punc>|</h-> <h- data-h=name>name</h-> <h- data-h=sym_punc>)</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>NOTATION</h-> <h- data-h=name>my_notation</h-> <h- data-h=kw>PUBLIC</h-> <h- data-h=str_dlim>"</h-><h- data-h=str_dlim>"</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ENTITY</h-> <h- data-h=name>my_entity</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>entity</h-><h- data-h=str_dlim>"</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ENTITY</h-> <h- data-h=name>my_entity</h-> <h- data-h=str_dlim>"</h-><h- data-h=str_esc>&amp;ref;</h-><h- data-h=str> abc</h-><h- data-h=str_dlim>"</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ENTITY</h-> <h- data-h=name>my_entity</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>abc %ref; abc</h-><h- data-h=str_dlim>"</h-> <h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ENTITY</h-> <h- data-h=name>my_entity</h-> <h- data-h=name>PULIC</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>incorrect type</h-><h- data-h=str_dlim>"</h-> <h- data-h=str_dlim>"</h-><h- data-h=str>extern</h-><h- data-h=str_dlim>"</h-> <h- data-h=kw>NDATA</h-> <h- data-h=name>data</h-><h- data-h=name_mac>&gt;</h->
+    <h- data-h=name_mac>&lt;!</h-><h- data-h=name_mac>ENTITY</h-> <h- data-h=sym_punc>%</h-> <h- data-h=name>my_entity</h-> <h- data-h=kw>PUBLIC</h-><h- data-h=name_mac>&gt;</h->
+<h- data-h=sym_punc>]</h-><h- data-h=name_mac>&gt;</h->


### PR DESCRIPTION
This PR adds support for the prolog of XML documents. 
Previously highlighting for

```
<?xml version=12312.00 encoding=UTF-8>
<!DOCTYPE xml-doc [
    <!ENTITY doc "doc">
   <!NOTATION my-notation PUBLIC "notation">
]>
```
was not supported. 
Note that in some places the highlighting is more permissive than the XML Standard (e.g in `PublicID` is matched with `expect_attribute_value`). 
This PR is not complete yet since I have not tested everything, I will add tests soon.