### PR TITLE
[cowel] Add block comments and remove special highlighting for `\comment` directive

### DIFF
--- a/include/ulight/impl/lang/cowel.hpp
+++ b/include/ulight/impl/lang/cowel.hpp
@@ -29,6 +29,20 @@ std::size_t match_whitespace(std::u8string_view str);
 [[nodiscard]]
 std::size_t match_line_comment(std::u8string_view str);
 
+struct Comment_Result {
+    std::size_t length;
+    bool is_terminated;
+
+    [[nodiscard]]
+    constexpr explicit operator bool() const noexcept
+    {
+        return length != 0;
+    }
+};
+
+[[nodiscard]]
+Comment_Result match_block_comment(std::u8string_view str);
+
 [[nodiscard]]
 Common_Number_Result match_number(std::u8string_view str);
 

--- a/include/ulight/impl/lang/cowel_chars.hpp
+++ b/include/ulight/impl/lang/cowel_chars.hpp
@@ -7,7 +7,8 @@
 
 namespace ulight {
 
-inline constexpr char8_t cowel_comment_char = u8':';
+inline constexpr char8_t cowel_line_comment_char = u8':';
+inline constexpr char8_t cowel_block_comment_char = u8'*';
 
 inline constexpr Charset256 is_cowel_special_set = detail::to_charset256(u8"{}\\(),=");
 
@@ -26,7 +27,8 @@ constexpr bool is_cowel_special(char32_t c) noexcept
 inline constexpr Charset256 is_cowel_escapeable_set
     = (is_ascii_punctuation_set //
        - detail::to_charset256(u8'_') //
-       - detail::to_charset256(cowel_comment_char)) //
+       - detail::to_charset256(cowel_line_comment_char)
+       - detail::to_charset256(cowel_block_comment_char)) //
     | detail::to_charset256(u8" \t\v\r\n");
 
 /// @brief Returns `true` if `c` is an escapable cowel character.
@@ -120,8 +122,11 @@ constexpr bool is_cowel_directive_name(char32_t c) noexcept
     return is_ascii(c) && is_cowel_directive_name(char8_t(c));
 }
 
-inline constexpr Charset256 is_cowel_allowed_after_backslash_set = is_cowel_escapeable_set
-    | is_cowel_directive_name_start_set | detail::to_charset256(cowel_comment_char);
+inline constexpr Charset256 is_cowel_allowed_after_backslash_set //
+    = is_cowel_escapeable_set //
+    | is_cowel_directive_name_start_set //
+    | detail::to_charset256(cowel_line_comment_char)
+    | detail::to_charset256(cowel_block_comment_char);
 
 [[nodiscard]]
 constexpr bool is_cowel_allowed_after_backslash(char8_t c) noexcept

--- a/test/highlight/cowel/comments.cow
+++ b/test/highlight/cowel/comments.cow
@@ -5,3 +5,6 @@
 \: nested \: comment
 trailing \: comment
 \: \dir[]{}
+\* awoo *\ \* chan *\
+\* \: *\ text
+\* unterminated

--- a/test/highlight/cowel/comments.cow.html
+++ b/test/highlight/cowel/comments.cow.html
@@ -5,3 +5,7 @@
 <h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> nested \: comment</h->
 trailing <h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> comment</h->
 <h- data-h=cmt_dlim>\:</h-><h- data-h=cmt> \dir[]{}</h->
+<h- data-h=cmt_dlim>\*</h-><h- data-h=cmt> awoo </h-><h- data-h=cmt_dlim>*\</h-> <h- data-h=cmt_dlim>\*</h-><h- data-h=cmt> chan </h-><h- data-h=cmt_dlim>*\</h->
+<h- data-h=cmt_dlim>\*</h-><h- data-h=cmt> \: </h-><h- data-h=cmt_dlim>*\</h-> text
+<h- data-h=cmt_dlim>\*</h-><h- data-h=cmt> unterminated
+</h->


### PR DESCRIPTION
See also
- https://github.com/eisenwave/cowel/issues/116